### PR TITLE
feat: Set NDArray as default build target in lakefile

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -47,6 +47,7 @@ lean_lib FuncTracker where
   globs := #[.andSubmodules `FuncTracker]
 
 /-- Main library. NumPy-compatible n-dimensional arrays -/
+@[default_target]
 lean_lib NDArray where
   -- Include all NDArray modules
   globs := #[.andSubmodules `NDArray]


### PR DESCRIPTION
This PR sets NDArray as the default build target in the lakefile by adding the `@[default_target]` attribute.

This is a clean redo of #78 based on the latest main branch.

## Changes
- Add `@[default_target]` attribute to the NDArray library definition
- This makes NDArray the default target when running `lake build` without specifying a target

🤖 Generated with [Claude Code](https://claude.ai/code)