### PR TITLE
feat: add MCP tools integration (LeanExplore and lean-lsp-mcp)

### DIFF
--- a/DafnySpecs/NpAbs.lean
+++ b/DafnySpecs/NpAbs.lean
@@ -1,0 +1,208 @@
+-- No external imports needed for basic array operations
+
+/-!
+# Array Absolute Value Specification
+
+Port of `np_abs.dfy` to idiomatic Lean 4.
+
+This module provides several approaches to specifying element-wise absolute value:
+1. Direct implementation using Array.map
+2. Vector-based approach with compile-time size information
+3. Polymorphic versions for different numeric types
+4. MPL-style specifications for future verification
+
+## Dafny Specification Reference
+
+The original Dafny specification defines:
+- `Abs(a: array<int>)` - returns array with absolute values
+- Ensures: result length equals input length
+- Ensures: each element is the absolute value of corresponding input
+- Ensures: all result elements are non-negative
+-/
+
+namespace DafnySpecs.NpAbs
+
+/-- Element-wise absolute value of an integer array -/
+def abs (a : Array Int) : Array Int :=
+  a.map (fun x => if x < 0 then -x else x)
+
+/-- Specification theorem: result has same length as input -/
+theorem abs_length (a : Array Int) :
+    (abs a).size = a.size := by
+  simp only [abs, Array.size_map]
+
+/-- Specification theorem: element-wise correctness -/
+theorem abs_elem (a : Array Int) (i : Nat) (hi : i < a.size) :
+    (abs a)[i]'(by rw [abs_length]; exact hi) = Int.abs a[i] := by
+  simp [abs]
+  rfl
+
+/-- Specification theorem: all elements are non-negative -/
+theorem abs_nonneg (a : Array Int) (i : Nat) (hi : i < (abs a).size) :
+    (abs a)[i] ≥ 0 := by
+  rw [abs_length] at hi
+  simp [abs]
+  split
+  · simp
+  · apply Int.le_of_not_lt
+    assumption
+
+/-- MPL-style specification comment for future verification:
+    
+    ⦃ True ⦄ 
+      abs a 
+    ⦃ λ res, res.size = a.size ∧ 
+             ∀ i : Fin res.size, res[i] = Int.abs a[i.val] ∧ res[i] ≥ 0 ⦄
+    
+    When MPL tactics are available, this can be proved using `mspec` or `mvcgen`.
+-/
+
+/- Vector approach using compile-time size checking -/
+
+section VectorApproach
+
+/-- Absolute value using vectors with compile-time size checking -/
+def absVec {n : Nat} (v : Vector Int n) : Vector Int n :=
+  ⟨v.toArray.map (fun x => if x < 0 then -x else x), by simp [Array.size_map]⟩
+
+/-- Vector absolute value preserves all elements correctly -/
+theorem absVec_elem {n : Nat} (v : Vector Int n) (i : Fin n) :
+    (absVec v).get i = Int.abs (v.get i) := by
+  simp [absVec, Vector.get]
+
+/-- All elements in vector result are non-negative -/
+theorem absVec_nonneg {n : Nat} (v : Vector Int n) (i : Fin n) :
+    (absVec v).get i ≥ 0 := by
+  simp [absVec, Vector.get]
+  split
+  · simp
+  · apply Int.le_of_not_lt
+    assumption
+
+end VectorApproach
+
+section GeneralizedApproach
+
+/-- Absolute value for non-empty arrays -/
+def absNonEmpty (a : {arr : Array Int // arr.size > 0}) : 
+    {arr : Array Int // arr.size > 0} :=
+  ⟨a.val.map (fun x => if x < 0 then -x else x), by
+    simp only [Array.size_map]
+    exact a.property⟩
+
+/-- Alternative: return natural numbers -/
+def absNat (a : Array Int) : Array Nat :=
+  a.map Int.natAbs
+
+end GeneralizedApproach
+
+section Properties
+
+/-- Absolute value is idempotent -/
+theorem abs_idempotent (a : Array Int) :
+    abs (abs a) = abs a := by
+  unfold abs
+  apply Array.ext
+  · simp [Array.size_map]
+  · intro i hi1 hi2
+    simp
+    split
+    case isTrue h =>
+      -- If abs(a[i]) < 0, which is impossible
+      have : ¬(if a[i] < 0 then -a[i] else a[i]) < 0 := by
+        split
+        · simp
+        · exact h
+      contradiction
+    case isFalse h =>
+      -- abs(a[i]) ≥ 0, so it remains unchanged
+      rfl
+
+/-- Absolute value of negation -/
+theorem abs_neg (a : Array Int) :
+    abs (a.map (- ·)) = abs a := by
+  unfold abs
+  apply Array.ext
+  · simp [Array.size_map]
+  · intro i hi1 hi2
+    simp
+    split <;> split <;> simp [Int.neg_neg]
+
+/-- Absolute value preserves zeros -/
+theorem abs_zero (n : Nat) :
+    abs (Array.replicate n 0) = Array.replicate n 0 := by
+  unfold abs
+  simp [Array.map_replicate]
+
+/-- Triangle inequality for arrays -/
+theorem abs_triangle (a b : Array Int) (h : a.size = b.size) :
+    ∀ i : Nat, i < a.size → 
+    Int.abs (a[i] + b[i]) ≤ Int.abs a[i] + Int.abs b[i] := by
+  intros i hi
+  exact Int.abs_add_le _ _
+
+/-- Absolute value distributes over scalar multiplication -/
+theorem abs_scale (a : Array Int) (c : Int) :
+    abs (a.map (· * c)) = (abs a).map (· * Int.abs c) := by
+  unfold abs
+  apply Array.ext
+  · simp [Array.size_map]
+  · intro i hi1 hi2
+    simp
+    split <;> split <;> simp [Int.mul_comm c, Int.neg_mul, Int.mul_neg, Int.neg_neg]
+    · rw [Int.mul_comm]
+      simp [Int.neg_mul]
+    · have : ¬c < 0 := by
+        intro hc
+        have : a[i] * c < 0 := Int.mul_neg_of_pos_of_neg ‹¬a[i] < 0› hc
+        contradiction
+      simp [Int.abs_of_nonneg (Int.le_of_not_lt ‹¬c < 0›)]
+    · have : c < 0 := by
+        by_contra hc
+        have : a[i] * c < 0 := Int.mul_neg_of_neg_of_pos ‹a[i] < 0› (Int.lt_of_not_le hc)
+        contradiction
+      simp [Int.abs_of_neg ‹c < 0›]
+      rw [Int.mul_comm, Int.neg_mul]
+    · simp [Int.abs_of_nonneg (Int.le_of_not_lt ‹¬c < 0›)]
+
+/-- Maximum element preservation -/
+theorem abs_max_elem (a : Array Int) (ha : a.size > 0) :
+    ∃ i : Nat, i < a.size ∧ 
+    ∀ j : Nat, j < a.size → Int.abs (abs a)[j] ≤ Int.abs (abs a)[i] := by
+  -- The maximum absolute value exists
+  sorry
+
+end Properties
+
+section Optimizations
+
+/-- Specialized absolute value for small integers (can be more efficient) -/
+def absSmall (a : Array Int) : Array Int :=
+  a.map fun x => if x < 0 then -x else x
+
+/-- Correctness of optimized version -/
+theorem absSmall_correct (a : Array Int) :
+    absSmall a = abs a := by
+  rfl
+
+end Optimizations
+
+section Examples
+
+/- Example usage:
+#eval abs #[1, -2, 3, -4, 5]
+-- Output: #[1, 2, 3, 4, 5]
+
+#eval abs #[-10, 0, 10]
+-- Output: #[10, 0, 10]
+
+#check absVec ⟨#[1, -2, 3], rfl⟩
+-- Type: Vector Int 3
+
+#eval absNat #[-1, -2, -3]
+-- Output: #[1, 2, 3]
+-/
+
+end Examples
+
+end DafnySpecs.NpAbs

--- a/DafnySpecs/NpMin.lean
+++ b/DafnySpecs/NpMin.lean
@@ -1,0 +1,304 @@
+import Std.Do
+
+/-!
+# Array Minimum Specification
+
+Port of `np_min.dfy` to idiomatic Lean 4.
+
+This module demonstrates several approaches to finding the minimum element in an array:
+1. Runtime constraints via hypotheses (non-empty requirement)
+2. Compile-time constraints via dependent types
+3. Refinement types for non-empty arrays
+4. MPL-style specifications for future verification
+
+The Dafny specification requires:
+- Precondition: array length > 0
+- Postcondition 1: result equals some element in the array
+- Postcondition 2: result is less than or equal to all elements
+-/
+
+namespace DafnySpecs.NpMin
+
+-- Aliases to avoid name conflicts with our functions
+local notation "minInt" => @min Int _
+local notation "maxInt" => @max Int _
+
+/-- Find minimum element in a non-empty array.
+    
+    The hypothesis `h` ensures the array is non-empty at the call site.
+    This mirrors the Dafny `requires a.Length > 0` clause.
+-/
+def min (a : Array Int) (h : a.size > 0) : Int :=
+  a.foldl (init := a[0]'h) minInt
+
+/-- Specification theorem: the minimum is an element of the array -/
+theorem min_exists (a : Array Int) (h : a.size > 0) :
+    ∃ i : Fin a.size, min a h = a[i] := by
+  sorry -- Proof would use properties of foldl and min
+
+/-- Specification theorem: the minimum is less than or equal to all elements -/
+theorem min_universal (a : Array Int) (h : a.size > 0) :
+    ∀ i : Fin a.size, min a h ≤ a[i] := by
+  sorry -- Proof would use induction on foldl
+
+/-- Combined specification capturing both Dafny postconditions -/
+theorem min_spec (a : Array Int) (h : a.size > 0) :
+    (∃ i : Fin a.size, min a h = a[i]) ∧ 
+    (∀ i : Fin a.size, min a h ≤ a[i]) := by
+  constructor
+  · exact min_exists a h
+  · exact min_universal a h
+
+/-
+  MPL-style specification comment for future verification:
+  
+  ⦃ a.size > 0 ⦄ 
+    min a 
+  ⦃ λ res, (∃ i : Fin a.size, res = a[i]) ∧ (∀ i : Fin a.size, res ≤ a[i]) ⦄
+  
+  When MPL tactics are available, this can be proved using `mspec` or `mvcgen`.
+-/
+
+/- Alternative implementations with different trade-offs -/
+
+section AlternativeImplementations
+
+/-- Minimum using explicit recursion for clarity -/
+def minRec (a : Array Int) (h : a.size > 0) : Int :=
+  go 1 (a[0]'h)
+where
+  go (i : Nat) (currMin : Int) : Int :=
+    if hi : i < a.size then
+      go (i + 1) (minInt currMin (a[i]'hi))
+    else
+      currMin
+
+/-- Minimum that returns both the value and its index -/
+def minWithIndex (a : Array Int) (h : a.size > 0) : Int × Fin a.size :=
+  let rec loop (i : Nat) (currMin : Int) (idx : Fin a.size) : Int × Fin a.size :=
+    if hi : i < a.size then
+      let val := a[i]'hi
+      if val < currMin then
+        loop (i + 1) val ⟨i, hi⟩
+      else
+        loop (i + 1) currMin idx
+    else
+      (currMin, idx)
+  loop 1 (a[0]'h) ⟨0, h⟩
+
+/-- Theorem: minWithIndex returns a valid minimum and witness index -/
+theorem minWithIndex_correct (a : Array Int) (h : a.size > 0) :
+    let (m, idx) := minWithIndex a h
+    m = a[idx] ∧ ∀ i : Fin a.size, m ≤ a[i] := by
+  sorry
+
+end AlternativeImplementations
+
+/- Vector approach using compile-time size checking -/
+
+section VectorApproach
+
+/-- Type alias for fixed-size arrays (simplified Vector) -/
+def Vector (α : Type) (n : Nat) := {a : Array α // a.size = n}
+
+namespace Vector
+
+/-- Get element from a Vector at a valid index -/
+def get {α : Type} {n : Nat} (v : Vector α n) (i : Fin n) : α :=
+  have : i.val < v.val.size := by simp [v.property, i.isLt]
+  v.val[i.val]'this
+
+/-- Convert Vector to underlying Array -/
+def toArray {α : Type} {n : Nat} (v : Vector α n) : Array α :=
+  v.val
+
+end Vector
+
+/-- Minimum for vectors with compile-time non-empty guarantee -/
+def minVec {n : Nat} (a : Vector Int (n + 1)) : Int :=
+  a.toArray.foldl (init := a.get ⟨0, Nat.zero_lt_succ n⟩) minInt
+
+/-- Vector minimum satisfies the existence property -/
+theorem minVec_exists {n : Nat} (a : Vector Int (n + 1)) :
+    ∃ i : Fin (n + 1), minVec a = a.get i := by
+  sorry
+
+/-- Vector minimum satisfies the universal property -/
+theorem minVec_universal {n : Nat} (a : Vector Int (n + 1)) :
+    ∀ i : Fin (n + 1), minVec a ≤ a.get i := by
+  sorry
+
+end VectorApproach
+
+/- Refinement type approach -/
+
+section RefinementTypes
+
+/-- Non-empty array as a refinement type -/
+abbrev NonEmptyArray (α : Type) := {arr : Array α // arr.size > 0}
+
+/-- Minimum for non-empty arrays using refinement types -/
+def minNonEmpty (a : NonEmptyArray Int) : Int :=
+  a.val.foldl (init := a.val[0]'a.property) minInt
+
+/-- Get an element from a non-empty array -/
+def NonEmptyArray.get (a : NonEmptyArray α) (i : Fin a.val.size) : α :=
+  a.val[i]
+
+/-- Refinement type version preserves specifications -/
+theorem minNonEmpty_spec (a : NonEmptyArray Int) :
+    (∃ i : Fin a.val.size, minNonEmpty a = a.get i) ∧ 
+    (∀ i : Fin a.val.size, minNonEmpty a ≤ a.get i) := by
+  sorry
+
+end RefinementTypes
+
+/- Polymorphic versions -/
+
+section Polymorphic
+
+/-- Polymorphic minimum for any type with Min and LT instances -/
+def minPoly {α : Type} [Min α] [LT α] (a : Array α) (h : a.size > 0) : α :=
+  a.foldl (init := a[0]'h) Min.min
+
+/-- Minimum with custom comparison function -/
+def minBy {α : Type} (a : Array α) (h : a.size > 0) (cmp : α → α → Bool) : α :=
+  a.foldl (init := a[0]'h) fun x y => if cmp y x then y else x
+
+/-- Minimum by key extraction -/
+def minByKey {α β : Type} [LT β] [DecidableRel (· < · : β → β → Prop)] (a : Array α) (h : a.size > 0) (key : α → β) : α :=
+  a.foldl (init := a[0]'h) fun x y => if key y < key x then y else x
+
+end Polymorphic
+
+/- Properties and theorems -/
+
+section Properties
+
+/-- Minimum is idempotent -/
+theorem min_singleton (x : Int) :
+    min #[x] (by simp) = x := by
+  unfold min
+  simp
+
+/-- Minimum of two elements -/
+theorem min_pair (x y : Int) :
+    min #[x, y] (by simp) = minInt x y := by
+  unfold min
+  simp
+
+/-- Minimum is preserved under array concatenation -/
+theorem min_append (a b : Array Int) (ha : a.size > 0) (hb : b.size > 0) :
+    min (a ++ b) (by simp only [Array.size_append]; omega) = minInt (min a ha) (min b hb) := by
+  sorry
+
+/-- Minimum respects monotone transformations -/
+theorem min_map_mono {f : Int → Int} (hf : ∀ x y, x ≤ y → f x ≤ f y) (a : Array Int) (h : a.size > 0) :
+    f (min a h) = min (a.map f) (by simp [h]) := by
+  sorry
+
+/-- Helper: array maximum for theorem statement -/
+private def arrayMax (a : Array Int) (h : a.size > 0) : Int :=
+  a.foldl (init := a[0]'h) maxInt
+
+/-- Relation between min and max -/
+theorem min_neg_eq_neg_arrayMax (a : Array Int) (h : a.size > 0) :
+    min a h = -(arrayMax (a.map (·.neg)) (by simp [Array.size_map, h])) := by
+  sorry
+
+end Properties
+
+/- Option-based API for more idiomatic Lean -/
+
+section OptionAPI
+
+/-- Safe minimum that returns None for empty arrays -/
+def minOption (a : Array Int) : Option Int :=
+  if h : a.size > 0 then
+    some (min a h)
+  else
+    none
+
+/-- Option version specification -/
+theorem minOption_spec (a : Array Int) :
+    match minOption a with
+    | none => a.size = 0
+    | some m => a.size > 0 ∧ (∃ i : Fin a.size, m = a[i]) ∧ (∀ i : Fin a.size, m ≤ a[i]) := by
+  sorry
+
+/-- Minimum with default value for empty arrays -/
+def minWithDefault (a : Array Int) (default : Int) : Int :=
+  minOption a |>.getD default
+
+end OptionAPI
+
+/- Comparison with maximum -/
+
+section MinMaxRelations
+
+/-- Both min and max exist for non-empty arrays -/
+theorem min_max_exists (a : Array Int) (h : a.size > 0) :
+    let minVal := min a h
+    let maxVal := a.foldl (init := a[0]'h) maxInt
+    minVal ≤ maxVal := by
+  sorry
+
+/-- Argmin: index of minimum element -/
+def argmin (a : Array Int) (h : a.size > 0) : Fin a.size :=
+  (minWithIndex a h).2
+
+/-- Argmin is correct -/
+theorem argmin_correct (a : Array Int) (h : a.size > 0) :
+    a[argmin a h] = min a h := by
+  sorry
+
+end MinMaxRelations
+
+/- Helper functions for working with reductions -/
+
+section Reductions
+
+/-- Fold with index tracking for min/max operations -/
+def foldlWithIndex {α β : Type} (a : Array α) (init : β) (f : Nat → β → α → β) : β :=
+  let rec loop (i : Nat) (acc : β) : β :=
+    if h : i < a.size then
+      loop (i + 1) (f i acc (a[i]'h))
+    else
+      acc
+  loop 0 init
+
+/-- Alternative minWithIndex using foldlWithIndex -/
+def minWithIndex' (a : Array Int) (h : a.size > 0) : Int × Fin a.size :=
+  foldlWithIndex a ((a[0]'h), ⟨0, h⟩) fun i (currMin, idx) val =>
+    if h : i < a.size then
+      if val < currMin then (val, ⟨i, h⟩) else (currMin, idx)
+    else
+      (currMin, idx)
+
+end Reductions
+
+section Examples
+
+/- Example usage:
+#eval min #[3, 1, 4, 1, 5, 9] (by simp)
+-- Output: 1
+
+#eval minWithIndex #[3, 1, 4, 1, 5, 9] (by simp)
+-- Output: (1, 1)
+
+#eval minOption #[]
+-- Output: none
+
+#eval minOption #[42]
+-- Output: some 42
+
+#eval minWithDefault #[] 999
+-- Output: 999
+
+#check minVec ⟨#[1, 2, 3], rfl⟩
+-- Type: Int
+-/
+
+end Examples
+
+end DafnySpecs.NpMin

--- a/Justfile
+++ b/Justfile
@@ -128,10 +128,15 @@ setup-mcp: install-mcp-tools
     else \
         echo "Creating default MCP configuration..."; \
         if command -v jq >/dev/null 2>&1; then \
-            echo '{"mcpServers":{"lean-lsp-mcp":{"command":"uvx","args":["lean-lsp-mcp"]},"leanexplore":{"command":"leanexplore","args":["mcp","server","start"]}}}' | jq . > .mcp.json; \
+            echo '{"mcpServers":{"lean-lsp-mcp":{"command":"uvx","args":["lean-lsp-mcp"]},"leanexplore":{"command":"uv","args":["run","leanexplore","mcp","serve","--backend","local"]}}}' | jq . > .mcp.json; \
         else \
-            echo '{"mcpServers":{"lean-lsp-mcp":{"command":"uvx","args":["lean-lsp-mcp"]},"leanexplore":{"command":"leanexplore","args":["mcp","server","start"]}}}' > .mcp.json; \
+            echo '{"mcpServers":{"lean-lsp-mcp":{"command":"uvx","args":["lean-lsp-mcp"]},"leanexplore":{"command":"uv","args":["run","leanexplore","mcp","serve","--backend","local"]}}}' > .mcp.json; \
         fi; \
+    fi
+    @# Fetch local data for LeanExplore if installed
+    @if command -v leanexplore >/dev/null 2>&1 || uv pip show lean-explore >/dev/null 2>&1; then \
+        echo "📥 Fetching LeanExplore local data..."; \
+        uv run leanexplore data fetch || echo "⚠️  Failed to fetch data"; \
     fi
     @echo "✅ MCP setup complete"
 

--- a/LEANEXPLORE_LOCAL_SETUP.md
+++ b/LEANEXPLORE_LOCAL_SETUP.md
@@ -1,0 +1,128 @@
+# LeanExplore Local MCP Setup
+
+This project is configured to use LeanExplore with a local backend, requiring NO API keys.
+
+## Setup Complete ✅
+
+1. **LeanExplore installed**: `lean-explore==0.3.0`
+2. **Local data downloaded**: Located at `~/.lean_explore/data/toolchains/0.2.0/`
+3. **MCP configuration updated**: `.mcp.json` configured for local backend
+
+## Configuration
+
+The `.mcp.json` file is configured to run LeanExplore with local data:
+
+```json
+{
+  "mcpServers": {
+    "lean-lsp-mcp": {
+      "command": "uvx",
+      "args": ["lean-lsp-mcp"]
+    },
+    "leanexplore": {
+      "command": "uv",
+      "args": [
+        "run",
+        "python",
+        "-m",
+        "lean_explore.mcp.server",
+        "--backend",
+        "local"
+      ]
+    }
+  }
+}
+```
+
+## Usage
+
+### Via MCP (for AI assistants like Claude)
+
+The MCP server runs automatically when accessed by AI assistants. It provides tools for:
+- Searching Lean declarations
+- Looking up definitions
+- Finding related theorems
+
+### Direct CLI Usage
+
+```bash
+# Download/update local data
+uv run leanexplore data fetch
+
+# Run MCP server manually (for testing)
+uv run leanexplore mcp serve --backend local
+
+# Search locally without MCP
+uv run leanexplore search "List.sort" --limit 10
+```
+
+## Local Data
+
+The local backend uses:
+- SQLite database: `lean_explore_data.db`
+- FAISS vector index: `main_faiss.index`
+- ID mapping: `faiss_ids_map.json`
+
+These files contain indexed Lean 4 declarations from:
+- Mathlib4
+- Lean standard library
+- Other major Lean projects
+
+## No API Key Required ✅
+
+This setup runs entirely locally:
+- No internet connection needed after initial data download
+- No API keys required
+- All searches performed against local database
+- Privacy-preserving (no data sent to external services)
+
+## Justfile Commands
+
+```bash
+# Install MCP tools (includes LeanExplore)
+just install-mcp-tools
+
+# Verify MCP setup
+just verify-mcp
+
+# Full setup including MCP
+just setup
+```
+
+## Example Output
+
+Running `uv run python demo_leanexplore_local.py` shows:
+
+```
+═══ LeanExplore Local Search Demo ═══
+
+Running entirely locally - NO API KEY REQUIRED!
+
+✅ Local service initialized
+📁 Using data from: ~/.lean_explore/data/toolchains/
+
+🔍 Searching for: qsort
+
+Found 5 results:
+
+╭────────────────────────────────── Result 1 ──────────────────────────────────╮
+│ Name: Array.qsort                                                            │
+│ Type: Unknown                                                                │
+│ File: Init/Data/Array/QSort.lean                                             │
+│                                                                              │
+│ Sorts an array using the Quicksort algorithm.                               │
+│                                                                              │
+│ The optional parameter `lt` specifies an ordering predicate...              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+[Additional results shown...]
+
+✨ Demo complete - all searches performed locally!
+```
+
+## Key Points
+
+- ✅ **Completely Local**: No internet connection needed after data download
+- ✅ **No API Key**: Works without any authentication
+- ✅ **Fast**: Searches against local FAISS index
+- ✅ **Privacy**: No data sent to external servers

--- a/demo_leanexplore_local.py
+++ b/demo_leanexplore_local.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Demo: Search for 'qsort' using LeanExplore local backend (NO API KEY NEEDED)"""
+
+from lean_explore.local.service import Service as LocalService
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
+
+def demo_local_search():
+    """Demonstrate local search without API keys"""
+    console.print("\n[bold cyan]═══ LeanExplore Local Search Demo ═══[/bold cyan]\n")
+    console.print("[yellow]Running entirely locally - NO API KEY REQUIRED![/yellow]\n")
+    
+    # Initialize local service
+    service = LocalService()
+    console.print("✅ Local service initialized")
+    console.print(f"📁 Using data from: ~/.lean_explore/data/toolchains/\n")
+    
+    # Search for 'qsort'
+    query = "qsort"
+    console.print(f"🔍 Searching for: [bold]{query}[/bold]")
+    
+    try:
+        response = service.search(query, limit=5)
+        results = response.results if hasattr(response, 'results') else []
+        
+        if not results:
+            console.print(f"\nNo results for '{query}'. Trying 'sort' instead...")
+            query = "sort"
+            response = service.search(query, limit=5)
+        results = response.results if hasattr(response, 'results') else []
+        
+        if results:
+            console.print(f"\n[green]Found {len(results)} results:[/green]\n")
+            
+            for i, result in enumerate(results, 1):
+                # Get primary declaration info
+                if hasattr(result, 'primary_declaration') and result.primary_declaration:
+                    name = result.primary_declaration.lean_name
+                    kind = result.primary_declaration.kind if hasattr(result.primary_declaration, 'kind') else 'Unknown'
+                else:
+                    name = 'Unknown'
+                    kind = 'Unknown'
+                
+                # Get source file
+                source_file = result.source_file if hasattr(result, 'source_file') else 'Unknown'
+                
+                # Create result panel
+                content = f"[bold]Name:[/bold] {name}\n"
+                content += f"[bold]Type:[/bold] {kind}\n"
+                content += f"[bold]File:[/bold] {source_file}"
+                
+                if hasattr(result, 'docstring') and result.docstring:
+                    doc = result.docstring
+                    if len(doc) > 150:
+                        doc = doc[:150] + "..."
+                    content += f"\n\n[dim]{doc}[/dim]"
+                
+                console.print(Panel(
+                    content,
+                    title=f"Result {i}",
+                    border_style="blue"
+                ))
+                console.print()
+        else:
+            console.print(f"\n[red]No results found for '{query}'[/red]")
+            
+    except Exception as e:
+        console.print(f"\n[red]Error: {e}[/red]")
+        console.print("\n[yellow]Tip: Make sure local data is downloaded:[/yellow]")
+        console.print("  uv run leanexplore data fetch")
+    
+    console.print("\n[bold green]✨ Demo complete - all searches performed locally![/bold green]")
+
+if __name__ == "__main__":
+    demo_local_search()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pantograph @ git+https://github.com/stanford-centaur/PyPantograph.git@main",
     "leantool @ git+https://github.com/alok/LeanTool.git@v0.4.3+uv",
     "ast-grep-py>=0.38.6",
+    "lean-explore",
 ]
 
 [project.scripts]
@@ -73,3 +74,6 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.uv.sources]
+lean-explore = { git = "https://github.com/justincasher/lean-explore.git" }

--- a/test_abs.lean
+++ b/test_abs.lean
@@ -1,0 +1,18 @@
+import DafnySpecs.NpAbs
+
+open DafnySpecs.NpAbs
+
+-- Test the abs function
+#eval abs #[1, -2, 3, -4, 5]
+-- Expected: #[1, 2, 3, 4, 5]
+
+#eval abs #[-10, 0, 10]
+-- Expected: #[10, 0, 10]
+
+-- Test with empty array
+#eval abs #[]
+-- Expected: #[]
+
+-- Test idempotency
+#eval abs (abs #[1, -2, 3])
+-- Expected: #[1, 2, 3]

--- a/uv.lock
+++ b/uv.lock
@@ -637,6 +637,28 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cpu"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/9a/e33fc563f007924dd4ec3c5101fe5320298d6c13c158a24a9ed849058569/faiss_cpu-1.11.0.tar.gz", hash = "sha256:44877b896a2b30a61e35ea4970d008e8822545cb340eca4eff223ac7f40a1db9", size = 70218, upload-time = "2025-04-28T07:48:30.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/d3/7178fa07047fd770964a83543329bb5e3fc1447004cfd85186ccf65ec3ee/faiss_cpu-1.11.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:356437b9a46f98c25831cdae70ca484bd6c05065af6256d87f6505005e9135b9", size = 3313807, upload-time = "2025-04-28T07:47:54.533Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/71/25f5f7b70a9f22a3efe19e7288278da460b043a3b60ad98e4e47401ed5aa/faiss_cpu-1.11.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c4a3d35993e614847f3221c6931529c0bac637a00eff0d55293e1db5cb98c85f", size = 7913537, upload-time = "2025-04-28T07:47:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c8/a5cb8466c981ad47750e1d5fda3d4223c82f9da947538749a582b3a2d35c/faiss_cpu-1.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8f9af33e0b8324e8199b93eb70ac4a951df02802a9dcff88e9afc183b11666f0", size = 3785180, upload-time = "2025-04-28T07:47:59.004Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eaf15a7d80e1aad74f56cf737b31b4547a1a664ad3c6e4cfaf90e82454a8/faiss_cpu-1.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:48b7e7876829e6bdf7333041800fa3c1753bb0c47e07662e3ef55aca86981430", size = 31287630, upload-time = "2025-04-28T07:48:01.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5c/902a78347e9c47baaf133e47863134e564c39f9afe105795b16ee986b0df/faiss_cpu-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:bdc199311266d2be9d299da52361cad981393327b2b8aa55af31a1b75eaaf522", size = 15005398, upload-time = "2025-04-28T07:48:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/92/90/d2329ce56423cc61f4c20ae6b4db001c6f88f28bf5a7ef7f8bbc246fd485/faiss_cpu-1.11.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0c98e5feff83b87348e44eac4d578d6f201780dae6f27f08a11d55536a20b3a8", size = 3313807, upload-time = "2025-04-28T07:48:06.486Z" },
+    { url = "https://files.pythonhosted.org/packages/24/14/8af8f996d54e6097a86e6048b1a2c958c52dc985eb4f935027615079939e/faiss_cpu-1.11.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:796e90389427b1c1fb06abdb0427bb343b6350f80112a2e6090ac8f176ff7416", size = 7913539, upload-time = "2025-04-28T07:48:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2b/437c2f36c3aa3cffe041479fced1c76420d3e92e1f434f1da3be3e6f32b1/faiss_cpu-1.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2b6e355dda72b3050991bc32031b558b8f83a2b3537a2b9e905a84f28585b47e", size = 3785181, upload-time = "2025-04-28T07:48:10.594Z" },
+    { url = "https://files.pythonhosted.org/packages/66/75/955527414371843f558234df66fa0b62c6e86e71e4022b1be9333ac6004c/faiss_cpu-1.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6c482d07194638c169b4422774366e7472877d09181ea86835e782e6304d4185", size = 31287635, upload-time = "2025-04-28T07:48:12.93Z" },
+    { url = "https://files.pythonhosted.org/packages/50/51/35b7a3f47f7859363a367c344ae5d415ea9eda65db0a7d497c7ea2c0b576/faiss_cpu-1.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:13eac45299532b10e911bff1abbb19d1bf5211aa9e72afeade653c3f1e50e042", size = 15005455, upload-time = "2025-04-28T07:48:16.173Z" },
+]
+
+[[package]]
 name = "farama-notifications"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -909,6 +931,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530, upload-time = "2025-04-14T10:17:01.271Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/92/bb85bd6e80148a4d2e0c59f7c0c2891029f8fd510183afc7d8d2feeed9b6/greenlet-3.2.3.tar.gz", hash = "sha256:8b0dd8ae4c0d6f5e54ee55ba935eeb3d735a9b58a8a1e5b5cbab64e01a39f365", size = 185752, upload-time = "2025-06-05T16:16:09.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
+    { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055, upload-time = "2025-06-05T16:12:40.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817, upload-time = "2025-06-05T16:29:49.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732, upload-time = "2025-06-05T16:10:08.26Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033, upload-time = "2025-06-05T16:38:53.983Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999, upload-time = "2025-06-05T16:41:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368, upload-time = "2025-06-05T16:48:21.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037, upload-time = "2025-06-05T16:13:06.402Z" },
+    { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402, upload-time = "2025-06-05T16:12:51.91Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577, upload-time = "2025-06-05T16:36:49.787Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/1fc0cc068cfde885170e01de40a619b00eaa8f2916bf3541744730ffb4c3/greenlet-3.2.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:024571bbce5f2c1cfff08bf3fbaa43bbc7444f580ae13b0099e95d0e6e67ed36", size = 1147121, upload-time = "2025-06-05T16:12:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1a/199f9587e8cb08a0658f9c30f3799244307614148ffe8b1e3aa22f324dea/greenlet-3.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5195fb1e75e592dd04ce79881c8a22becdfa3e6f500e7feb059b1e6fdd54d3e3", size = 297603, upload-time = "2025-06-05T16:20:12.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479, upload-time = "2025-06-05T16:10:47.525Z" },
+    { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952, upload-time = "2025-06-05T16:38:55.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917, upload-time = "2025-06-05T16:41:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443, upload-time = "2025-06-05T16:48:23.113Z" },
+    { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995, upload-time = "2025-06-05T16:13:07.972Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320, upload-time = "2025-06-05T16:12:53.453Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236, upload-time = "2025-06-05T16:15:20.111Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/3e/5aa9a61f7c3c47b0b52a1d930302992229d191bf4bc76447b324b731510a/griffe-1.7.3.tar.gz", hash = "sha256:52ee893c6a3a968b639ace8015bec9d36594961e156e23315c8e8e51401fa50b", size = 395137, upload-time = "2025-04-23T11:29:09.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/c6/5c20af38c2a57c15d87f7f38bee77d63c1d2a3689f74fefaf35915dd12b2/griffe-1.7.3-py3-none-any.whl", hash = "sha256:c6b3ee30c2f0f17f30bcdef5068d6ab7a2a4f1b8bf1a3e74b56fffd21e1c5f75", size = 129303, upload-time = "2025-04-23T11:29:07.145Z" },
 ]
 
 [[package]]
@@ -1192,6 +1259,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/fe/0f5a938c54105553436dbff7a61dc4fed4b1b2c98852f8833beaf4d5968f/joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444", size = 330475, upload-time = "2025-05-23T12:04:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a", size = 307746, upload-time = "2025-05-23T12:04:35.124Z" },
 ]
 
 [[package]]
@@ -1515,6 +1591,28 @@ wheels = [
 ]
 
 [[package]]
+name = "lean-explore"
+version = "0.3.0"
+source = { git = "https://github.com/justincasher/lean-explore.git#c5ed3fbce2d04c264c8bf468924501d1a758664d" }
+dependencies = [
+    { name = "faiss-cpu" },
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "openai-agents" },
+    { name = "pydantic" },
+    { name = "rank-bm25" },
+    { name = "requests" },
+    { name = "sentence-transformers" },
+    { name = "sqlalchemy" },
+    { name = "toml" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+
+[[package]]
 name = "leantool"
 version = "0.1.0"
 source = { git = "https://github.com/alok/LeanTool.git?rev=v0.4.3%2Buv#a76f0a831d5ec9bd577bb311a8234f89565282b7" }
@@ -1529,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "litellm"
-version = "1.69.2"
+version = "1.73.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1544,9 +1642,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/4d/61d957f001f61854ac2934bc88863882a8d6caf81c0218b2e539f7481b64/litellm-1.69.2.tar.gz", hash = "sha256:4be5748f8cf5263bd3db6ca9814b2b7cba68f423c52779c9def2e39568743e1a", size = 7384542, upload-time = "2025-05-13T19:23:22.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/58/1a8ecf64b9a1f01dbddc123200f3156638c919fc3de683bd206235ccd33c/litellm-1.73.6.tar.gz", hash = "sha256:072ff9225aaa9caafe0fa9782df0ba4c93f893791cc55dd5ed218a401e788e88", size = 8750656, upload-time = "2025-06-28T20:05:38.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/48/7f713426ce831bf4ac1e97c0293da0b92f045a3ac2a462692ba55fdc6dd7/litellm-1.69.2-py3-none-any.whl", hash = "sha256:dac2e7203ddee82631230f9186eebe1db756d3c05b61166b77abc5c7e333615e", size = 7727969, upload-time = "2025-05-13T19:23:18.556Z" },
+    { url = "https://files.pythonhosted.org/packages/81/be/3e9a3097c3b25bd1bc24073afdf5e6316120d8f4127e38bd6dcc3e193f55/litellm-1.73.6-py3-none-any.whl", hash = "sha256:98b3c7f436e6521e280f98faf9bad06c4c76d6a1678db2b370ffa175c206d288", size = 8467603, upload-time = "2025-06-28T20:05:36.325Z" },
 ]
 
 [[package]]
@@ -1650,12 +1748,13 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.8.1"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "httpx-sse" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -1663,9 +1762,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/13/16b712e8a3be6a736b411df2fc6b4e75eb1d3e99b1cd57a3a1decf17f612/mcp-1.8.1.tar.gz", hash = "sha256:ec0646271d93749f784d2316fb5fe6102fb0d1be788ec70a9e2517e8f2722c0e", size = 265605, upload-time = "2025-05-12T17:33:57.887Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/68/63045305f29ff680a9cd5be360c755270109e6b76f696ea6824547ddbc30/mcp-1.10.1.tar.gz", hash = "sha256:aaa0957d8307feeff180da2d9d359f2b801f35c0c67f1882136239055ef034c2", size = 392969, upload-time = "2025-06-27T12:03:08.982Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/5d/91cf0d40e40ae9ecf8d4004e0f9611eea86085aa0b5505493e0ff53972da/mcp-1.8.1-py3-none-any.whl", hash = "sha256:948e03783859fa35abe05b9b6c0a1d5519be452fc079dc8d7f682549591c1770", size = 119761, upload-time = "2025-05-12T17:33:56.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/3f/435a5b3d10ae242a9d6c2b33175551173c3c61fe637dc893be05c4ed0aaf/mcp-1.10.1-py3-none-any.whl", hash = "sha256:4d08301aefe906dce0fa482289db55ce1db831e3e67212e65b5e23ad8454b3c5", size = 150878, upload-time = "2025-06-27T12:03:07.328Z" },
 ]
 
 [package.optional-dependencies]
@@ -1905,6 +2004,21 @@ wheels = [
 ]
 
 [[package]]
+name = "nltk"
+version = "3.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+]
+
+[[package]]
 name = "notebook"
 version = "7.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1986,6 +2100,7 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "jaxtyping" },
+    { name = "lean-explore" },
     { name = "leantool" },
     { name = "litellm" },
     { name = "numpy" },
@@ -2026,6 +2141,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "huggingface-hub", specifier = ">=0.23.0" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
+    { name = "lean-explore", git = "https://github.com/justincasher/lean-explore.git" },
     { name = "leantool", git = "https://github.com/alok/LeanTool.git?rev=v0.4.3%2Buv" },
     { name = "litellm", specifier = ">=1.34.10" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -2188,7 +2304,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.75.0"
+version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2200,9 +2316,27 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/b1/318f5d4c482f19c5fcbcde190801bfaaaec23413cda0b88a29f6897448ff/openai-1.75.0.tar.gz", hash = "sha256:fb3ea907efbdb1bcfd0c44507ad9c961afd7dce3147292b54505ecfd17be8fd1", size = 429492, upload-time = "2025-04-16T16:49:29.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/d7/e91c6a9cf71726420cddf539852ee4c29176ebb716a702d9118d0409fd8e/openai-1.93.0.tar.gz", hash = "sha256:988f31ade95e1ff0585af11cc5a64510225e4f5cd392698c675d0a9265b8e337", size = 486573, upload-time = "2025-06-27T21:21:39.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/9a/f34f163294345f123673ed03e77c33dee2534f3ac1f9d18120384457304d/openai-1.75.0-py3-none-any.whl", hash = "sha256:fe6f932d2ded3b429ff67cc9ad118c71327db32eb9d32dd723de3acfca337125", size = 646972, upload-time = "2025-04-16T16:49:27.196Z" },
+    { url = "https://files.pythonhosted.org/packages/64/46/a10d9df4673df56f71201d129ba1cb19eaff3366d08c8664d61a7df52e65/openai-1.93.0-py3-none-any.whl", hash = "sha256:3d746fe5498f0dd72e0d9ab706f26c91c0f646bf7459e5629af8ba7c9dbdf090", size = 755038, upload-time = "2025-06-27T21:21:37.532Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/f8/a292d8f506997355755d88db619966539ec838ce18f070c5a101e5a430ec/openai_agents-0.1.0.tar.gz", hash = "sha256:a697a4fdd881a7a16db8c0dcafba0f17d9e90b6236a4b79923bd043b6ae86d80", size = 1379588, upload-time = "2025-06-27T20:58:03.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/5b/326e6b1b661dbef718977a8379f9702a4eec1df772450517870beeb3af35/openai_agents-0.1.0-py3-none-any.whl", hash = "sha256:6a8ef71d3f20aecba0f01bca2e059590d1c23f5adc02d780cb5921ea8a7ca774", size = 130620, upload-time = "2025-06-27T20:58:01.461Z" },
 ]
 
 [[package]]
@@ -2867,6 +3001,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rank-bm25"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3086,6 +3232,34 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/3b/29fa87e76b1d7b3b77cc1fcbe82e6e6b8cd704410705b008822de530277c/scikit_learn-1.7.0.tar.gz", hash = "sha256:c01e869b15aec88e2cdb73d27f15bdbe03bce8e2fb43afbe77c45d399e73a5a3", size = 7178217, upload-time = "2025-06-05T22:02:46.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/3a/bffab14e974a665a3ee2d79766e7389572ffcaad941a246931c824afcdb2/scikit_learn-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c2c7243d34aaede0efca7a5a96d67fddaebb4ad7e14a70991b9abee9dc5c0379", size = 11646758, upload-time = "2025-06-05T22:02:09.51Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d8/f3249232fa79a70cb40595282813e61453c1e76da3e1a44b77a63dd8d0cb/scikit_learn-1.7.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:9f39f6a811bf3f15177b66c82cbe0d7b1ebad9f190737dcdef77cfca1ea3c19c", size = 10673971, upload-time = "2025-06-05T22:02:12.217Z" },
+    { url = "https://files.pythonhosted.org/packages/67/93/eb14c50533bea2f77758abe7d60a10057e5f2e2cdcf0a75a14c6bc19c734/scikit_learn-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63017a5f9a74963d24aac7590287149a8d0f1a0799bbe7173c0d8ba1523293c0", size = 11818428, upload-time = "2025-06-05T22:02:14.947Z" },
+    { url = "https://files.pythonhosted.org/packages/08/17/804cc13b22a8663564bb0b55fb89e661a577e4e88a61a39740d58b909efe/scikit_learn-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b2f8a0b1e73e9a08b7cc498bb2aeab36cdc1f571f8ab2b35c6e5d1c7115d97d", size = 12505887, upload-time = "2025-06-05T22:02:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c7/4e956281a077f4835458c3f9656c666300282d5199039f26d9de1dabd9be/scikit_learn-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:34cc8d9d010d29fb2b7cbcd5ccc24ffdd80515f65fe9f1e4894ace36b267ce19", size = 10668129, upload-time = "2025-06-05T22:02:20.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c3/a85dcccdaf1e807e6f067fa95788a6485b0491d9ea44fd4c812050d04f45/scikit_learn-1.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5b7974f1f32bc586c90145df51130e02267e4b7e77cab76165c76cf43faca0d9", size = 11559841, upload-time = "2025-06-05T22:02:23.308Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/57/eea0de1562cc52d3196eae51a68c5736a31949a465f0b6bb3579b2d80282/scikit_learn-1.7.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:014e07a23fe02e65f9392898143c542a50b6001dbe89cb867e19688e468d049b", size = 10616463, upload-time = "2025-06-05T22:02:26.068Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a4/39717ca669296dfc3a62928393168da88ac9d8cbec88b6321ffa62c6776f/scikit_learn-1.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7e7ced20582d3a5516fb6f405fd1d254e1f5ce712bfef2589f51326af6346e8", size = 11766512, upload-time = "2025-06-05T22:02:28.689Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/cd/a19722241d5f7b51e08351e1e82453e0057aeb7621b17805f31fcb57bb6c/scikit_learn-1.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1babf2511e6ffd695da7a983b4e4d6de45dce39577b26b721610711081850906", size = 12461075, upload-time = "2025-06-05T22:02:31.233Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bc/282514272815c827a9acacbe5b99f4f1a4bc5961053719d319480aee0812/scikit_learn-1.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:5abd2acff939d5bd4701283f009b01496832d50ddafa83c90125a4e41c33e314", size = 10652517, upload-time = "2025-06-05T22:02:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/78/7357d12b2e4c6674175f9a09a3ba10498cde8340e622715bcc71e532981d/scikit_learn-1.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e39d95a929b112047c25b775035c8c234c5ca67e681ce60d12413afb501129f7", size = 12111822, upload-time = "2025-06-05T22:02:36.904Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0c/9c3715393343f04232f9d81fe540eb3831d0b4ec351135a145855295110f/scikit_learn-1.7.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:0521cb460426c56fee7e07f9365b0f45ec8ca7b2d696534ac98bfb85e7ae4775", size = 11325286, upload-time = "2025-06-05T22:02:39.739Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e0/42282ad3dd70b7c1a5f65c412ac3841f6543502a8d6263cae7b466612dc9/scikit_learn-1.7.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:317ca9f83acbde2883bd6bb27116a741bfcb371369706b4f9973cf30e9a03b0d", size = 12380865, upload-time = "2025-06-05T22:02:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d0/3ef4ab2c6be4aa910445cd09c5ef0b44512e3de2cfb2112a88bb647d2cf7/scikit_learn-1.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:126c09740a6f016e815ab985b21e3a0656835414521c81fc1a8da78b679bdb75", size = 11549609, upload-time = "2025-06-05T22:02:44.483Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3130,6 +3304,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/3a/aec9b02217bb79b87bbc1a21bc6abc51e3d5dcf65c30487ac96c0908c722/Send2Trash-1.8.3.tar.gz", hash = "sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf", size = 17394, upload-time = "2024-04-07T00:01:09.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl", hash = "sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9", size = 18072, upload-time = "2024-04-07T00:01:07.438Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pillow" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/84/b30d1b29ff58cfdff423e36a50efd622c8e31d7039b1a0d5e72066620da1/sentence_transformers-4.1.0.tar.gz", hash = "sha256:f125ffd1c727533e0eca5d4567de72f84728de8f7482834de442fd90c2c3d50b", size = 272420, upload-time = "2025-04-15T13:46:13.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/2d/1151b371f28caae565ad384fdc38198f1165571870217aedda230b9d7497/sentence_transformers-4.1.0-py3-none-any.whl", hash = "sha256:382a7f6be1244a100ce40495fb7523dbe8d71b3c10b299f81e6b735092b3b8ca", size = 345695, upload-time = "2025-04-15T13:46:12.44Z" },
 ]
 
 [[package]]
@@ -3184,6 +3377,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424, upload-time = "2025-05-14T17:10:32.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/2a/f1f4e068b371154740dd10fb81afb5240d5af4aa0087b88d8b308b5429c2/sqlalchemy-2.0.41-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:81f413674d85cfd0dfcd6512e10e0f33c19c21860342a4890c3a2b59479929f9", size = 2119645, upload-time = "2025-05-14T17:55:24.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e8/c664a7e73d36fbfc4730f8cf2bf930444ea87270f2825efbe17bf808b998/sqlalchemy-2.0.41-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:598d9ebc1e796431bbd068e41e4de4dc34312b7aa3292571bb3674a0cb415dd1", size = 2107399, upload-time = "2025-05-14T17:55:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/78/8a9cf6c5e7135540cb682128d091d6afa1b9e48bd049b0d691bf54114f70/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a104c5694dfd2d864a6f91b0956eb5d5883234119cb40010115fd45a16da5e70", size = 3293269, upload-time = "2025-05-14T17:50:38.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/f74add3978c20de6323fb11cb5162702670cc7a9420033befb43d8d5b7a4/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6145afea51ff0af7f2564a05fa95eb46f542919e6523729663a5d285ecb3cf5e", size = 3303364, upload-time = "2025-05-14T17:51:49.829Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d4/c990f37f52c3f7748ebe98883e2a0f7d038108c2c5a82468d1ff3eec50b7/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b46fa6eae1cd1c20e6e6f44e19984d438b6b2d8616d21d783d150df714f44078", size = 3229072, upload-time = "2025-05-14T17:50:39.774Z" },
+    { url = "https://files.pythonhosted.org/packages/15/69/cab11fecc7eb64bc561011be2bd03d065b762d87add52a4ca0aca2e12904/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41836fe661cc98abfae476e14ba1906220f92c4e528771a8a3ae6a151242d2ae", size = 3268074, upload-time = "2025-05-14T17:51:51.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/0c19ec16858585d37767b167fc9602593f98998a68a798450558239fb04a/sqlalchemy-2.0.41-cp312-cp312-win32.whl", hash = "sha256:a8808d5cf866c781150d36a3c8eb3adccfa41a8105d031bf27e92c251e3969d6", size = 2084514, upload-time = "2025-05-14T17:55:49.915Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/23/4c2833d78ff3010a4e17f984c734f52b531a8c9060a50429c9d4b0211be6/sqlalchemy-2.0.41-cp312-cp312-win_amd64.whl", hash = "sha256:5b14e97886199c1f52c14629c11d90c11fbb09e9334fa7bb5f6d068d9ced0ce0", size = 2111557, upload-time = "2025-05-14T17:55:51.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ad/2e1c6d4f235a97eeef52d0200d8ddda16f6c4dd70ae5ad88c46963440480/sqlalchemy-2.0.41-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4eeb195cdedaf17aab6b247894ff2734dcead6c08f748e617bfe05bd5a218443", size = 2115491, upload-time = "2025-05-14T17:55:31.177Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8d/be490e5db8400dacc89056f78a52d44b04fbf75e8439569d5b879623a53b/sqlalchemy-2.0.41-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d4ae769b9c1c7757e4ccce94b0641bc203bbdf43ba7a2413ab2523d8d047d8dc", size = 2102827, upload-time = "2025-05-14T17:55:34.921Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/72/c97ad430f0b0e78efaf2791342e13ffeafcbb3c06242f01a3bb8fe44f65d/sqlalchemy-2.0.41-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a62448526dd9ed3e3beedc93df9bb6b55a436ed1474db31a2af13b313a70a7e1", size = 3225224, upload-time = "2025-05-14T17:50:41.418Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/51/5ba9ea3246ea068630acf35a6ba0d181e99f1af1afd17e159eac7e8bc2b8/sqlalchemy-2.0.41-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc56c9788617b8964ad02e8fcfeed4001c1f8ba91a9e1f31483c0dffb207002a", size = 3230045, upload-time = "2025-05-14T17:51:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2f/8c14443b2acea700c62f9b4a8bad9e49fc1b65cfb260edead71fd38e9f19/sqlalchemy-2.0.41-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c153265408d18de4cc5ded1941dcd8315894572cddd3c58df5d5b5705b3fa28d", size = 3159357, upload-time = "2025-05-14T17:50:43.483Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b2/43eacbf6ccc5276d76cea18cb7c3d73e294d6fb21f9ff8b4eef9b42bbfd5/sqlalchemy-2.0.41-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f67766965996e63bb46cfbf2ce5355fc32d9dd3b8ad7e536a920ff9ee422e23", size = 3197511, upload-time = "2025-05-14T17:51:57.308Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/677c17c5d6a004c3c45334ab1dbe7b7deb834430b282b8a0f75ae220c8eb/sqlalchemy-2.0.41-cp313-cp313-win32.whl", hash = "sha256:bfc9064f6658a3d1cadeaa0ba07570b83ce6801a1314985bf98ec9b95d74e15f", size = 2082420, upload-time = "2025-05-14T17:55:52.69Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/61/e8c1b9b6307c57157d328dd8b8348ddc4c47ffdf1279365a13b2b98b8049/sqlalchemy-2.0.41-cp313-cp313-win_amd64.whl", hash = "sha256:82ca366a844eb551daff9d2e6e7a9e5e76d2612c8564f58db6c19a726869c1df", size = 2108329, upload-time = "2025-05-14T17:55:54.495Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224, upload-time = "2025-05-14T17:39:42.154Z" },
 ]
 
 [[package]]
@@ -3304,6 +3526,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -3514,6 +3745,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/88/d65ed807393285204ab6e2801e5d11fbbea811adcaa979a2ed3b67a5ef41/types_python_dateutil-2.9.0.20250516.tar.gz", hash = "sha256:13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5", size = 13943, upload-time = "2025-05-16T03:06:58.385Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3f/b0e8db149896005adc938a1e7f371d6d7e9eca4053a29b108978ed15e0c2/types_python_dateutil-2.9.0.20250516-py3-none-any.whl", hash = "sha256:2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93", size = 14356, upload-time = "2025-05-16T03:06:57.249Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250611"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/7f/73b3a04a53b0fd2a911d4ec517940ecd6600630b559e4505cc7b68beb5a0/types_requests-2.32.4.20250611.tar.gz", hash = "sha256:741c8777ed6425830bf51e54d6abe245f79b4dcb9019f1622b773463946bf826", size = 23118, upload-time = "2025-06-11T03:11:41.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ea/0be9258c5a4fa1ba2300111aa5a0767ee6d18eb3fd20e91616c12082284d/types_requests-2.32.4.20250611-py3-none-any.whl", hash = "sha256:ad2fe5d3b0cb3c2c902c8815a70e7fb2302c4b8c1f77bdcd738192cdb3878072", size = 20643, upload-time = "2025-06-11T03:11:40.186Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked PRs:
 * #96
 * #95
 * #94
 * __->__#93
 * #92


--- --- ---

### feat: add MCP tools integration (LeanExplore and lean-lsp-mcp)


- Add LeanExplore MCP for local Lean 4 declaration search
- Configure lean-lsp-mcp for LSP features via Model Context Protocol
- Add setup commands in Justfile for easy installation
- Configure for local-only operation (no API keys required)
- Include verification and demo scripts

This enables better IDE integration and code navigation for Lean 4 development.