### PR TITLE
feat: port 38 NumPy operations from Dafny to Lean 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /**/.lake/
 external/morphcloud-examples-public/
+.history/
 
 # Ignore generated artefacts but keep Lean sources
 /generated/**

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
         "lean-lsp-mcp"
       ]
     },
-    "leanexplore": {
+    "leanexploreLocal": {
       "command": "uv",
       "args": [
         "run",

--- a/DafnySpecs/dfy_syntax/NpAbs.lean
+++ b/DafnySpecs/dfy_syntax/NpAbs.lean
@@ -1,0 +1,20 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for absolute value -/
+def AbsInt (x : Int) : Int := if x < 0 then -x else x
+
+/-- Computes the absolute value of each element in an array -/
+def abs (a : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: abs returns an array of the same size with absolute values -/
+theorem abs_spec (a : Array Int) :
+    ⦃⌜a.size > 0⌝⦄
+    abs a
+    ⦃⇓res => ∃ hr : res.size = a.size,
+             (∀ i (hi : i < res.size), res[i] = AbsInt (a[i]'(hr ▸ hi))) ∧
+             (∀ i (hi : i < res.size), res[i] ≥ 0)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpAdd.lean
+++ b/DafnySpecs/dfy_syntax/NpAdd.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Adds two arrays element-wise -/
+def add (a b : Array Int): Id (Array Int) :=
+  sorry
+
+/-- Specification: add returns an array of the same size with element-wise sums -/
+theorem add_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    add a b
+    ⦃⇓r => ∃ hr : r.size = a.size, ∀ i (hi : i < r.size), r[i] = a[i] + b[i]⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpArange.lean
+++ b/DafnySpecs/dfy_syntax/NpArange.lean
@@ -1,0 +1,21 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns evenly spaced values within a given interval -/
+def arange (start stop step : Float) : Id (Array Float) :=
+  sorry
+
+/-- Specification: arange returns an array of evenly spaced values -/
+theorem arange_spec (start stop step : Float) 
+    (h1 : if step < 0.0 then start > stop else start < stop)
+    (h2 : step ≠ 0.0) :
+    ⦃⌜(if step < 0.0 then start > stop else start < stop) ∧ step ≠ 0.0⌝⦄
+    arange start stop step
+    ⦃⇓ret => ∃ hr1 : ret.size = ((stop - start)/step).floor.toUInt64.toNat, 
+             ∃ hr2 : ret.size > 0,
+             ∃ hr3 : ret[0]'(by simp [hr2]) = start,
+             ∀ i (hi : 1 ≤ i) (hi2 : i < ret.size), 
+               ret[i]'hi2 - ret[i-1]'(by omega) = step⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpArgmax.lean
+++ b/DafnySpecs/dfy_syntax/NpArgmax.lean
@@ -1,0 +1,17 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the index of the maximum value in an array (first occurrence) -/
+def argmax (arr : Array Float) : Id Nat :=
+  sorry
+
+/-- Specification: argmax returns the index of the first maximum element -/
+theorem argmax_spec (arr : Array Float) (h : arr.size > 0) :
+    ⦃⌜arr.size > 0⌝⦄
+    argmax arr
+    ⦃⇓ret => ∃ hr : ret < arr.size,
+             (∀ i (hi : i < ret), arr[ret]'hr > arr[i]'(by omega)) ∧
+             (∀ i, ret < i → ∀ hi : i < arr.size, arr[ret]'hr ≥ arr[i]'hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpBitwiseAnd.lean
+++ b/DafnySpecs/dfy_syntax/NpBitwiseAnd.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for bitwise AND of integers -/
+def BitwiseAndInt (x y : Int) : Int :=
+  sorry
+
+/-- Performs bitwise AND on two arrays element-wise -/
+def bitwiseAnd (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: bitwiseAnd returns an array with element-wise bitwise AND -/
+theorem bitwiseAnd_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    bitwiseAnd a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = BitwiseAndInt (a[i]'(hr ▸ hi)) (b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpBitwiseOr.lean
+++ b/DafnySpecs/dfy_syntax/NpBitwiseOr.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for bitwise OR of integers -/
+def BitwiseOrInt (x y : Int) : Int :=
+  sorry
+
+/-- Performs bitwise OR on two arrays element-wise -/
+def bitwiseOr (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: bitwiseOr returns an array with element-wise bitwise OR -/
+theorem bitwiseOr_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    bitwiseOr a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = BitwiseOrInt (a[i]'(hr ▸ hi)) (b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpBitwiseXor.lean
+++ b/DafnySpecs/dfy_syntax/NpBitwiseXor.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for bitwise XOR of integers -/
+def BitwiseXorInt (x y : Int) : Int :=
+  sorry
+
+/-- Performs bitwise XOR on two arrays element-wise -/
+def bitwiseXor (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: bitwiseXor returns an array with element-wise bitwise XOR -/
+theorem bitwiseXor_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    bitwiseXor a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = BitwiseXorInt (a[i]'(hr ▸ hi)) (b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpCenter.lean
+++ b/DafnySpecs/dfy_syntax/NpCenter.lean
@@ -1,0 +1,21 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Centers each string in an array within a string of specified width -/
+def center (input : Array String) (width : Nat) : Id (Array String) :=
+  sorry
+
+/-- Specification: center returns an array with centered strings -/
+theorem center_spec (input : Array String) (width : Nat) 
+    (h : ∀ i (hi : i < input.size), (input[i]'hi).length ≥ 1) :
+    ⦃⌜∀ i (hi : i < input.size), (input[i]'hi).length ≥ 1⌝⦄
+    center input width
+    ⦃⇓res => ∃ hr1 : res.size = input.size,
+             ∀ i (hi : i < input.size), 
+               if (input[i]'hi).length > width then 
+                 (res[i]'(hr1 ▸ hi)).length = (input[i]'hi).length 
+               else 
+                 (res[i]'(hr1 ▸ hi)).length = width⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpCopy.lean
+++ b/DafnySpecs/dfy_syntax/NpCopy.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns a copy of the given array -/
+def copy (arr : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: copy returns an array with the same length and elements -/
+theorem copy_spec (arr : Array Int) :
+    ⦃⌜True⌝⦄
+    copy arr
+    ⦃⇓ret => ∃ hr : ret.size = arr.size,
+             ∀ i : Nat, ∀ hi : i < ret.size, ret[i]'hi = arr[i]'(hr ▸ hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpCumProd.lean
+++ b/DafnySpecs/dfy_syntax/NpCumProd.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Computes the cumulative product of array elements -/
+def cumProd (a : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: cumProd returns an array with cumulative products -/
+theorem cumProd_spec (a : Array Int) (h : a.size > 0) :
+    ⦃⌜a.size > 0⌝⦄
+    cumProd a
+    ⦃⇓res => ∃ hr : res.size = a.size,
+             (∃ h0 : 0 < res.size, res[0]'h0 = a[0]'h) ∧
+             (∀ i (hi : 1 ≤ i) (hi2 : i < a.size), 
+               ∃ hir : i < res.size, ∃ hir1 : i-1 < res.size,
+               res[i]'hir = res[i-1]'hir1 * a[i]'hi2)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpCumSum.lean
+++ b/DafnySpecs/dfy_syntax/NpCumSum.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Computes the cumulative sum of array elements -/
+def cumSum (a : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: cumSum returns an array with cumulative sums -/
+theorem cumSum_spec (a : Array Int) (h : a.size > 0) :
+    ⦃⌜a.size > 0⌝⦄
+    cumSum a
+    ⦃⇓res => ∃ hr : res.size = a.size,
+             (∃ h0 : 0 < res.size, res[0]'h0 = a[0]'h) ∧
+             (∀ i (hi : 1 ≤ i) (hi2 : i < a.size), 
+               ∃ hir : i < res.size, ∃ hir1 : i-1 < res.size,
+               res[i]'hir = res[i-1]'hir1 + a[i]'hi2)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpEqual.lean
+++ b/DafnySpecs/dfy_syntax/NpEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two arrays element-wise for equality -/
+def equal (a b : Array Int) : Id (Array Bool) :=
+  sorry
+
+/-- Specification: equal returns an array of booleans indicating element-wise equality -/
+theorem equal_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    equal a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = (a[i]'(hr ▸ hi) = b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpFlatten.lean
+++ b/DafnySpecs/dfy_syntax/NpFlatten.lean
@@ -1,0 +1,24 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Flattens a 2D array into a 1D array -/
+def flatten2 (mat : Array (Array Int)) : Id (Array Int) :=
+  sorry
+
+/-- Specification: flatten2 returns a 1D array with all elements from the 2D array -/
+theorem flatten2_spec (mat : Array (Array Int)) 
+    (h1 : mat.size > 0) 
+    (h2 : ∀ i (hi : i < mat.size), (mat[i]'hi).size > 0)
+    (h3 : ∀ i j (hi : i < mat.size) (hj : j < mat.size), (mat[i]'hi).size = (mat[j]'hj).size) :
+    ⦃⌜mat.size > 0 ∧ (∀ i (hi : i < mat.size), (mat[i]'hi).size > 0) ∧ 
+      (∀ i j (hi : i < mat.size) (hj : j < mat.size), (mat[i]'hi).size = (mat[j]'hj).size)⌝⦄
+    flatten2 mat
+    ⦃⇓ret => ∃ cols : Nat, ∃ h0 : 0 < mat.size, ∃ hcols : cols = (mat[0]'h0).size,
+             ∃ hr : ret.size = mat.size * cols,
+             ∀ i j (hi : i < mat.size) (hj : j < cols), 
+               ∃ hidx : i * cols + j < ret.size,
+               ∃ hjcols : j < (mat[i]'hi).size,
+               ret[i * cols + j]'hidx = (mat[i]'hi)[j]'hjcols⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpFloorDivide.lean
+++ b/DafnySpecs/dfy_syntax/NpFloorDivide.lean
@@ -1,0 +1,18 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Element-wise floor division on two arrays -/
+def floorDivide (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: floorDivide returns an array with element-wise integer division -/
+theorem floorDivide_spec (a b : Array Int) 
+    (h_size : a.size = b.size)
+    (h_nonzero : ∀ i (hi : i < b.size), b[i] ≠ 0) :
+    ⦃⌜a.size = b.size ∧ ∀ i (hi : i < b.size), b[i] ≠ 0⌝⦄
+    floorDivide a b
+    ⦃⇓r => ∃ hr : r.size = a.size,
+           ∀ i (hi : i < r.size), r[i]'hi = a[i]'(hr ▸ hi) / b[i]'(h_size ▸ hr ▸ hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpGreater.lean
+++ b/DafnySpecs/dfy_syntax/NpGreater.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two arrays element-wise for greater than -/
+def greater (a b : Array Int) : Id (Array Bool) :=
+  sorry
+
+/-- Specification: greater returns an array of booleans indicating element-wise comparison -/
+theorem greater_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    greater a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = (a[i]'(hr ▸ hi) > b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpGreaterEqual.lean
+++ b/DafnySpecs/dfy_syntax/NpGreaterEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two arrays element-wise for greater than or equal -/
+def greaterEqual (a b : Array Int) : Id (Array Bool) :=
+  sorry
+
+/-- Specification: greaterEqual returns an array of booleans indicating element-wise comparison -/
+theorem greaterEqual_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    greaterEqual a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = (a[i]'(hr ▸ hi) ≥ b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpInvert.lean
+++ b/DafnySpecs/dfy_syntax/NpInvert.lean
@@ -1,0 +1,20 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Bitwise NOT operation on an integer -/
+def bitwiseNot (n : Int) : Int :=
+  sorry  -- This would be implemented using bitwise operations
+
+/-- Compute bitwise NOT of each array element -/
+def invert (a : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: invert returns an array of the same size with bitwise NOT applied -/
+theorem invert_spec (a : Array Int) :
+    ⦃⌜a.size ≥ 0⌝⦄
+    invert a
+    ⦃⇓r => ∃ (hr : r.size = a.size), 
+           ∀ i (hi : i < a.size), r[i]'(hr ▸ hi) = bitwiseNot a[i]⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpLeftShift.lean
+++ b/DafnySpecs/dfy_syntax/NpLeftShift.lean
@@ -1,0 +1,22 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Left shift operation on integers -/
+def shiftLeft (n : Int) (shift : Nat) : Int :=
+  sorry  -- This would be implemented using bitwise operations
+
+/-- Element-wise left shift operation on two arrays -/
+def leftShift (a : Array Int) (b : Array Nat) : Id (Array Int) :=
+  sorry
+
+/-- Specification: leftShift returns an array with element-wise left shift -/
+theorem leftShift_spec (a : Array Int) (b : Array Nat) 
+    (h_size : a.size = b.size)
+    (h_bound : ∀ i (hi : i < b.size), b[i] < 64) :
+    ⦃⌜a.size = b.size ∧ ∀ i (hi : i < b.size), b[i] < 64⌝⦄
+    leftShift a b
+    ⦃⇓r => ∃ (hr : r.size = a.size), 
+           ∀ i (hi : i < r.size), r[i]'hi = shiftLeft (a[i]'(hr ▸ hi)) (b[i]'(h_size ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpLess.lean
+++ b/DafnySpecs/dfy_syntax/NpLess.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two arrays element-wise for less than -/
+def less (a b : Array Int) : Id (Array Bool) :=
+  sorry
+
+/-- Specification: less returns an array of booleans indicating element-wise comparison -/
+theorem less_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    less a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = (a[i]'(hr ▸ hi) < b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpLessEqual.lean
+++ b/DafnySpecs/dfy_syntax/NpLessEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two arrays element-wise for less than or equal -/
+def lessEqual (a b : Array Int) : Id (Array Bool) :=
+  sorry
+
+/-- Specification: lessEqual returns an array of booleans indicating element-wise comparison -/
+theorem lessEqual_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    lessEqual a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = (a[i]'(hr ▸ hi) ≤ b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpMax.lean
+++ b/DafnySpecs/dfy_syntax/NpMax.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Finds the maximum element in an array -/
+def max (a : Array Int) : Id Int :=
+  sorry
+
+/-- Specification: max returns the maximum element from a non-empty array -/
+theorem max_spec (a : Array Int) (h : a.size > 0) :
+    ⦃⌜a.size > 0⌝⦄
+    max a
+    ⦃⇓res => ∃ i : Nat, ∃ hi : i < a.size, res = a[i]'hi ∧
+             ∀ j : Nat, ∀ hj : j < a.size, a[j]'hj ≤ res⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpMin.lean
+++ b/DafnySpecs/dfy_syntax/NpMin.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Finds the minimum element in an array -/
+def min (a : Array Int) : Id Int :=
+  sorry
+
+/-- Specification: min returns the minimum element from a non-empty array -/
+theorem min_spec (a : Array Int) (h : a.size > 0) :
+    ⦃⌜a.size > 0⌝⦄
+    min a
+    ⦃⇓res => ∃ i : Nat, ∃ hi : i < a.size, res = a[i]'hi ∧
+             ∀ j : Nat, ∀ hj : j < a.size, res ≤ a[j]'hj⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpMod.lean
+++ b/DafnySpecs/dfy_syntax/NpMod.lean
@@ -1,0 +1,18 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Element-wise modulo operation on two arrays -/
+def mod (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: mod returns an array with element-wise modulo -/
+theorem mod_spec (a b : Array Int) 
+    (h_size : a.size = b.size)
+    (h_nonzero : ∀ i (hi : i < b.size), b[i] ≠ 0) :
+    ⦃⌜a.size = b.size ∧ ∀ i (hi : i < b.size), b[i] ≠ 0⌝⦄
+    mod a b
+    ⦃⇓r => ∃ (hr : r.size = a.size), 
+           ∀ i (hi : i < a.size), r[i]'(hr ▸ hi) = a[i] % b[i]'(h_size ▸ hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpMultiply.lean
+++ b/DafnySpecs/dfy_syntax/NpMultiply.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Multiplies two arrays element-wise -/
+def multiply (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: multiply returns an array of the same size with element-wise products -/
+theorem multiply_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    multiply a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = a[i]'(hr ▸ hi) * b[i]'(h ▸ hr ▸ hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpNotEqual.lean
+++ b/DafnySpecs/dfy_syntax/NpNotEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two arrays element-wise for inequality -/
+def notEqual (a b : Array Int) : Id (Array Bool) :=
+  sorry
+
+/-- Specification: notEqual returns an array of booleans indicating element-wise comparison -/
+theorem notEqual_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    notEqual a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = (a[i]'(hr ▸ hi) ≠ b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpPower.lean
+++ b/DafnySpecs/dfy_syntax/NpPower.lean
@@ -1,0 +1,21 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Power function for integers -/
+def pow (base : Int) (exp : Nat) : Int :=
+  sorry  -- This would be implemented as integer power
+
+/-- Element-wise power operation on two arrays -/
+def power (a : Array Int) (b : Array Nat) : Id (Array Int) :=
+  sorry
+
+/-- Specification: power returns an array with element-wise exponentiation -/
+theorem power_spec (a : Array Int) (b : Array Nat) 
+    (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    power a b
+    ⦃⇓r => ∃ (hr : r.size = a.size), 
+           ∀ i (hi : i < r.size), r[i]'hi = pow (a[i]'(hr ▸ hi)) (b[i]'(h ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpProd.lean
+++ b/DafnySpecs/dfy_syntax/NpProd.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function to compute product of array elements from start to endPos -/
+def ProdArray (a : Array Int) (start : Nat) (endPos : Nat) : Int :=
+  sorry
+
+/-- Computes the product of all elements in an array -/
+def prod (a : Array Int) : Id Int :=
+  sorry
+
+/-- Specification: prod returns the product of all array elements -/
+theorem prod_spec (a : Array Int) :
+    ⦃⌜a.size > 0⌝⦄
+    prod a
+    ⦃⇓res => res = ProdArray a 0 a.size⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpReshape.lean
+++ b/DafnySpecs/dfy_syntax/NpReshape.lean
@@ -1,0 +1,59 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- 2D array type -/
+structure Array2 (α : Type) where
+  /-- The underlying 1D array storing elements in row-major order -/
+  data : Array α
+  /-- Number of rows -/
+  rows : Nat
+  /-- Number of columns -/
+  cols : Nat
+  /-- Invariant: data size equals rows * cols -/
+  h_size : data.size = rows * cols
+
+/-- Get element at position (i, j) in a 2D array -/
+def Array2.get (arr : Array2 α) (i j : Nat) (hi : i < arr.rows) (hj : j < arr.cols) : α :=
+  arr.data[i * arr.cols + j]'(by
+    rw [arr.h_size]
+    have h1 : i * arr.cols + j < i * arr.cols + arr.cols := Nat.add_lt_add_left hj _
+    have h2 : i * arr.cols + arr.cols = (i + 1) * arr.cols := by 
+      rw [←Nat.succ_mul, Nat.succ_eq_add_one]
+    have h3 : (i + 1) * arr.cols ≤ arr.rows * arr.cols := 
+      Nat.mul_le_mul_right _ (Nat.succ_le_of_lt hi)
+    omega)
+
+/-- Reshape a 1D array into a 2D array -/
+def reshape (arr : Array Int) (shape : Array Int) : Id (Array2 Int) :=
+  sorry
+
+/-- Specification: reshape returns a 2D array with the specified dimensions -/
+theorem reshape_spec (arr : Array Int) (shape : Array Int)
+    (h_shape_len : shape.size = 2)
+    (h_valid : ∀ i (hi : i < 2), shape[i] > 0 ∨ shape[i] = -1)
+    (h_not_both_neg : ¬(shape[0] = -1 ∧ shape[1] = -1))
+    (h_size : if shape[0] > 0 ∧ shape[1] > 0 then 
+                shape[0] * shape[1] = arr.size
+              else if shape[0] = -1 then 
+                arr.size % shape[1] = 0
+              else 
+                arr.size % shape[0] = 0) :
+    ⦃⌜shape.size = 2 ∧ 
+      (∀ i (hi : i < 2), shape[i] > 0 ∨ shape[i] = -1) ∧
+      ¬(shape[0] = -1 ∧ shape[1] = -1) ∧
+      (if shape[0] > 0 ∧ shape[1] > 0 then 
+         shape[0] * shape[1] = arr.size
+       else if shape[0] = -1 then 
+         arr.size % shape[1] = 0
+       else 
+         arr.size % shape[0] = 0)⌝⦄
+    reshape arr shape
+    ⦃⇓r => (if shape[0] > 0 then r.rows = shape[0].natAbs else r.rows = arr.size / shape[1].natAbs) ∧
+           (if shape[1] > 0 then r.cols = shape[1].natAbs else r.cols = arr.size / shape[0].natAbs) ∧
+           ∀ i (hi : i < arr.size), 
+             have hr : i / r.cols < r.rows := sorry
+             have hc : i % r.cols < r.cols := sorry
+             r.get (i / r.cols) (i % r.cols) hr hc = arr[i]⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpRightShift.lean
+++ b/DafnySpecs/dfy_syntax/NpRightShift.lean
@@ -1,0 +1,22 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Right shift operation on integers -/
+def shiftRight (n : Int) (shift : Nat) : Int :=
+  sorry  -- This would be implemented using bitwise operations
+
+/-- Element-wise right shift operation on two arrays -/
+def rightShift (a : Array Int) (b : Array Nat) : Id (Array Int) :=
+  sorry
+
+/-- Specification: rightShift returns an array with element-wise right shift -/
+theorem rightShift_spec (a : Array Int) (b : Array Nat) 
+    (h_size : a.size = b.size)
+    (h_bound : ∀ i (hi : i < b.size), b[i] < 64) :
+    ⦃⌜a.size = b.size ∧ ∀ i (hi : i < b.size), b[i] < 64⌝⦄
+    rightShift a b
+    ⦃⇓r => ∃ (hr : r.size = a.size), 
+           ∀ i (hi : i < r.size), r[i]'hi = shiftRight (a[i]'(hr ▸ hi)) (b[i]'(h_size ▸ hr ▸ hi))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpSign.lean
+++ b/DafnySpecs/dfy_syntax/NpSign.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the sign of each element in an array -/
+def sign (a : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: sign returns an array with -1, 0, or 1 based on element signs -/
+theorem sign_spec (a : Array Int) :
+    ⦃⌜True⌝⦄
+    sign a
+    ⦃⇓res => ∃ hr : res.size = a.size, 
+             ∀ i (hi : i < res.size), 
+               (a[i]'(hr ▸ hi) > 0 → res[i]'hi = 1) ∧
+               (a[i]'(hr ▸ hi) = 0 → res[i]'hi = 0) ∧
+               (a[i]'(hr ▸ hi) < 0 → res[i]'hi = -1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpSquare.lean
+++ b/DafnySpecs/dfy_syntax/NpSquare.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the element-wise square of the input array -/
+def square (arr : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: square returns an array of the same size with squared elements -/
+theorem square_spec (arr : Array Int) :
+    ⦃⌜arr.size > 0⌝⦄
+    square arr
+    ⦃⇓ret => ∃ hr : ret.size = arr.size,
+             ∀ i : Nat, ∀ hi : i < ret.size, ret[i]'hi = arr[i]'(hr ▸ hi) * arr[i]'(hr ▸ hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpSubtract.lean
+++ b/DafnySpecs/dfy_syntax/NpSubtract.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Subtracts two arrays element-wise -/
+def subtract (a b : Array Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: subtract returns an array of the same size with element-wise differences -/
+theorem subtract_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    subtract a b
+    ⦃⇓res => ∃ hr : res.size = a.size, ∀ i (hi : i < res.size), res[i]'hi = a[i]'(hr ▸ hi) - b[i]'(h ▸ hr ▸ hi)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpSum.lean
+++ b/DafnySpecs/dfy_syntax/NpSum.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function to compute sum of array elements from start to endPos -/
+def SumArray (a : Array Int) (start : Nat) (endPos : Nat) : Int :=
+  sorry
+
+/-- Computes the sum of all elements in an array -/
+def sum (a : Array Int) : Id Int :=
+  sorry
+
+/-- Specification: sum returns the sum of all array elements -/
+theorem sum_spec (a : Array Int) :
+    ⦃⌜a.size > 0⌝⦄
+    sum a
+    ⦃⇓res => res = SumArray a 0 a.size⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpWhere.lean
+++ b/DafnySpecs/dfy_syntax/NpWhere.lean
@@ -1,0 +1,18 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Return elements chosen from x or y depending on condition -/
+def «where» (condition : Int → Bool) (arr : Array Int) (change : Int → Int) : Id (Array Int) :=
+  sorry
+
+/-- Specification: where returns an array of the same size with elements conditionally changed -/
+theorem where_spec (condition : Int → Bool) (arr : Array Int) (change : Int → Int) 
+    (h : arr.size > 0) :
+    ⦃⌜arr.size > 0⌝⦄
+    «where» condition arr change
+    ⦃⇓r => ∃ (hr : r.size = arr.size), 
+           ∀ i (hi : i < arr.size), 
+             r[i]'(hr ▸ hi) = if condition arr[i] then change arr[i] else arr[i]⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax/NpZeros.lean
+++ b/DafnySpecs/dfy_syntax/NpZeros.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Creates a 2D array of zeros with the given shape -/
+def zeros (shape : Array Nat) : Id (Array Int) :=
+  sorry
+
+/-- Specification: zeros returns an array of zeros with the specified dimensions -/
+theorem zeros_spec (shape : Array Nat) (h1 : shape.size = 2) (h2 : shape[0]'(by simp [h1]) > 0) (h3 : shape[1]'(by simp [h1]) > 0) :
+    ⦃⌜shape.size = 2 ∧ shape[0]'(by simp [h1]) > 0 ∧ shape[1]'(by simp [h1]) > 0⌝⦄
+    zeros shape
+    ⦃⇓ret => ∃ hr : ret.size = shape[0]'(by simp [h1]) * shape[1]'(by simp [h1]),
+             ∀ i : Nat, ∀ hi : i < ret.size, ret[i]'hi = 0⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Absolute.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Absolute.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.absolute: Calculate the absolute value element-wise.
+    
+    Computes the absolute value of each element in the input array.
+    For complex numbers, this is the magnitude. For real numbers,
+    this is the standard absolute value.
+    
+    Returns an array of the same shape as x, containing the absolute values.
+-/
+def numpy_absolute {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.absolute returns a vector where each element is the 
+    absolute value of the corresponding element in x.
+    
+    Precondition: True (no special preconditions for absolute value)
+    Postcondition: For all indices i, result[i] = |x[i]|
+-/
+theorem numpy_absolute_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_absolute x
+    ⦃⇓result => ∀ i : Fin n, result.get i = Float.abs (x.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Add.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Add.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.add: Add arguments element-wise.
+    
+    Adds two vectors element-wise. If the vectors have the same shape,
+    each element of the result is the sum of the corresponding elements
+    from the input vectors.
+    
+    This is equivalent to x1 + x2 in terms of array broadcasting.
+-/
+def numpy_add {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.add returns a vector where each element is the sum
+    of the corresponding elements from x1 and x2.
+    
+    Precondition: True (no special preconditions for basic addition)
+    Postcondition: For all indices i, result[i] = x1[i] + x2[i]
+-/
+theorem numpy_add_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_add x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = x1.get i + x2.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_All.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_All.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.all: Test whether all array elements evaluate to True.
+    
+    Returns True if all elements in the array evaluate to True,
+    False otherwise. For empty arrays, returns True (vacuous truth).
+    
+    This is a reduction operation that performs logical AND across
+    all boolean values in the array.
+-/
+def numpy_all {n : Nat} (a : Vector Bool n) : Id Bool :=
+  sorry
+
+/-- Specification: numpy.all returns true iff all elements are true.
+    
+    Precondition: True (works for any boolean vector, including empty)
+    Postcondition: result = true iff all elements are true (true for empty vector)
+-/
+theorem numpy_all_spec {n : Nat} (a : Vector Bool n) :
+    ⦃⌜True⌝⦄
+    numpy_all a
+    ⦃⇓result => result = (∀ i : Fin n, a.get i = true)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Any.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Any.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.any: Test whether any array element evaluates to True.
+    
+    Returns True if at least one element in the array evaluates to True,
+    False otherwise. For empty arrays, returns False.
+    
+    This is a reduction operation that performs logical OR across
+    all boolean values in the array.
+-/
+def numpy_any {n : Nat} (a : Vector Bool n) : Id Bool :=
+  sorry
+
+/-- Specification: numpy.any returns true iff at least one element is true.
+    
+    Precondition: True (works for any boolean vector, including empty)
+    Postcondition: result = true iff at least one element is true (false for empty vector)
+-/
+theorem numpy_any_spec {n : Nat} (a : Vector Bool n) :
+    ⦃⌜True⌝⦄
+    numpy_any a
+    ⦃⇓result => result = (∃ i : Fin n, a.get i = true)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Argmax.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Argmax.lean
@@ -1,0 +1,25 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.argmax: Returns the index of the maximum value.
+    
+    Returns the index of the maximum value among all elements in the array.
+    Requires a non-empty array since there is no maximum of an empty set.
+    
+    This function returns the position of the largest element in the array.
+-/
+def numpy_argmax (a : Vector Float (n + 1)) : Id (Fin (n + 1)) :=
+  sorry
+
+/-- Specification: numpy.argmax returns the index of the maximum element.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: The element at the returned index is the maximum value
+-/
+theorem numpy_argmax_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_argmax a
+    ⦃⇓i => ∀ j : Fin (n + 1), a.get j ≤ a.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Argmin.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Argmin.lean
@@ -1,0 +1,25 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.argmin: Returns the index of the minimum value.
+    
+    Returns the index of the minimum value among all elements in the array.
+    Requires a non-empty array since there is no minimum of an empty set.
+    
+    This function returns the position of the smallest element in the array.
+-/
+def numpy_argmin (a : Vector Float (n + 1)) : Id (Fin (n + 1)) :=
+  sorry
+
+/-- Specification: numpy.argmin returns the index of the minimum element.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: The element at the returned index is the minimum value
+-/
+theorem numpy_argmin_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_argmin a
+    ⦃⇓i => ∀ j : Fin (n + 1), a.get i ≤ a.get j⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Argsort.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Argsort.lean
@@ -1,0 +1,25 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.argsort: Returns the indices that would sort an array.
+    
+    Returns an array of indices that would sort the input array in ascending order.
+    These indices can be used to reorder the original array into sorted order.
+    
+    This function performs an indirect sort, returning indices rather than values.
+-/
+def numpy_argsort (a : Vector Float n) : Id (Vector (Fin n) n) :=
+  sorry
+
+/-- Specification: numpy.argsort returns indices that sort the array.
+    
+    Precondition: True
+    Postcondition: Using the returned indices produces a sorted array
+-/
+theorem numpy_argsort_spec (a : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_argsort a
+    ⦃⇓indices => ∀ i j : Fin n, i < j → a.get (indices.get i) ≤ a.get (indices.get j)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Clip.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Clip.lean
@@ -1,0 +1,29 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.clip: Clip (limit) the values in an array.
+    
+    Given an interval [min, max], values outside the interval are clipped 
+    to the interval edges. For example, if an interval of [0, 1] is specified, 
+    values smaller than 0 become 0, and values larger than 1 become 1.
+    
+    This is an element-wise operation that bounds each value in the array.
+-/
+def numpy_clip {n : Nat} (a : Vector Float n) (min max : Float) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.clip returns a vector with all values clipped to [min, max].
+    
+    Precondition: min ≤ max
+    Postcondition: Each element in result is clipped to the interval [min, max]
+-/
+theorem numpy_clip_spec {n : Nat} (a : Vector Float n) (min max : Float) :
+    ⦃⌜min ≤ max⌝⦄
+    numpy_clip a min max
+    ⦃⇓result => ∀ i : Fin n, 
+      let x := a.get i
+      let y := result.get i
+      y = if x < min then min else if x > max then max else x⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Concatenate.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Concatenate.lean
@@ -1,0 +1,29 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.concatenate: Join a sequence of arrays along an existing axis.
+    
+    For 1D arrays, concatenate joins arrays end-to-end. This is the
+    simplest form of concatenation - appending one array after another.
+    The result has length equal to the sum of input lengths.
+    
+    This version handles concatenating two 1D arrays. The general version
+    would handle a list of arrays.
+-/
+def numpy_concatenate {n m : Nat} (a : Vector Float n) (b : Vector Float m) : 
+    Id (Vector Float (n + m)) :=
+  sorry
+
+/-- Specification: numpy.concatenate appends the second array after the first.
+    
+    Precondition: True (no special preconditions for basic concatenation)
+    Postcondition: First n elements come from a, next m elements come from b
+-/
+theorem numpy_concatenate_spec {n m : Nat} (a : Vector Float n) (b : Vector Float m) :
+    ⦃⌜True⌝⦄
+    numpy_concatenate a b
+    ⦃⇓result => (∀ i : Fin n, result.get (i.castAdd m) = a.get i) ∧
+                (∀ j : Fin m, result.get (j.natAdd n) = b.get j)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Cos.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Cos.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.cos: Trigonometric cosine, element-wise.
+    
+    The cosine is one of the fundamental functions of trigonometry.
+    For a real number x interpreted as an angle in radians, cos(x)
+    gives the x-coordinate of the point on the unit circle.
+    
+    Returns an array of the same shape as x, containing the cosine of each element.
+-/
+def numpy_cos {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.cos returns a vector where each element is the cosine
+    of the corresponding element in x (interpreted as radians).
+    
+    Precondition: True (no special preconditions for cosine)
+    Postcondition: For all indices i, result[i] = Float.cos x[i]
+-/
+theorem numpy_cos_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_cos x
+    ⦃⇓result => ∀ i : Fin n, result.get i = Float.cos (x.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Divide.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Divide.lean
@@ -1,0 +1,28 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.divide: Divide arguments element-wise.
+    
+    Divides arguments element-wise. If the arrays have the same shape,
+    each element of the result is the quotient of the corresponding elements
+    from the input arrays.
+    
+    This is equivalent to x1 / x2 in terms of array broadcasting.
+    Note: Division by zero will result in infinity or NaN depending on the numerator.
+-/
+def numpy_divide {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.divide returns a vector where each element is the quotient
+    of the corresponding elements from x1 and x2.
+    
+    Precondition: All elements in x2 must be non-zero
+    Postcondition: For all indices i, result[i] = x1[i] / x2[i]
+-/
+theorem numpy_divide_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜∀ i : Fin n, x2.get i ≠ 0⌝⦄
+    numpy_divide x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = x1.get i / x2.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Dot.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Dot.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.dot: Dot product of two arrays.
+    
+    For 1-D arrays (vectors), this is the inner product of vectors.
+    It computes the sum of the element-wise products of the input vectors.
+    
+    If both a and b are 1-D arrays, it is inner product of vectors
+    (without complex conjugation).
+-/
+def numpy_dot {n : Nat} (a b : Vector Float n) : Id Float :=
+  sorry
+
+/-- Specification: numpy.dot returns the dot product (inner product) of two vectors.
+    
+    Precondition: True (vectors must have same length, enforced by type)
+    Postcondition: result = sum(a[i] * b[i] for all i)
+-/
+theorem numpy_dot_spec {n : Nat} (a b : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_dot a b
+    ⦃⇓result => result = List.sum (List.zipWith (· * ·) a.toList b.toList)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Exp.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Exp.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.exp: Calculate the exponential of all elements in the input array.
+    
+    Computes e^x for each element x in the input array, where e is Euler's number.
+    The natural exponential function is the inverse of the natural logarithm.
+    
+    Returns an array of the same shape as x, containing the exponential of each element.
+-/
+def numpy_exp {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.exp returns a vector where each element is e raised to
+    the power of the corresponding element in x.
+    
+    Precondition: True (no special preconditions for exponential)
+    Postcondition: For all indices i, result[i] = Float.exp x[i]
+-/
+theorem numpy_exp_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_exp x
+    ⦃⇓result => ∀ i : Fin n, result.get i = Float.exp (x.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Log.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Log.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.log: Natural logarithm, element-wise.
+    
+    The natural logarithm log is the inverse of the exponential function,
+    so that log(exp(x)) = x. The natural logarithm is logarithm base e.
+    
+    Returns an array of the same shape as x, containing the natural logarithm
+    of each element in x.
+-/
+def numpy_log {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.log returns a vector where each element is the natural
+    logarithm of the corresponding element in x.
+    
+    Precondition: All elements must be positive (x[i] > 0)
+    Postcondition: For all indices i, result[i] = Float.log x[i]
+-/
+theorem numpy_log_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜∀ i : Fin n, x.get i > 0⌝⦄
+    numpy_log x
+    ⦃⇓result => ∀ i : Fin n, result.get i = Float.log (x.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Matmul.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Matmul.lean
@@ -1,0 +1,29 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.matmul: Matrix product of two arrays.
+    
+    For 1-D arrays (vectors), this function behaves the same as numpy.dot,
+    computing the inner product of vectors. It returns the sum of the 
+    element-wise products of the input vectors.
+    
+    Note: For 2-D arrays and higher dimensions, matmul performs matrix
+    multiplication following specific broadcasting rules, but for 1-D
+    vectors it is identical to the dot product.
+-/
+def numpy_matmul {n : Nat} (x1 x2 : Vector Float n) : Id Float :=
+  sorry
+
+/-- Specification: numpy.matmul returns the matrix product of two arrays.
+    For 1-D vectors, this is the same as the dot product.
+    
+    Precondition: True (vectors must have same length, enforced by type)
+    Postcondition: result = sum(x1[i] * x2[i] for all i)
+-/
+theorem numpy_matmul_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_matmul x1 x2
+    ⦃⇓result => result = List.sum (List.zipWith (· * ·) x1.toList x2.toList)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Max.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Max.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.max: Maximum value in array.
+    
+    Returns the maximum value among all elements in the array.
+    Requires a non-empty array since there is no maximum of an empty set.
+    
+    This is a reduction operation that finds the largest value in the array.
+-/
+def numpy_max (a : Vector Float (n + 1)) : Id Float :=
+  sorry
+
+/-- Specification: numpy.max returns the maximum element in the vector.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: result is the maximum value and is an element of the vector
+-/
+theorem numpy_max_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_max a
+    ⦃⇓result => (∃ i : Fin (n + 1), a.get i = result) ∧ 
+                (∀ i : Fin (n + 1), a.get i ≤ result)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Maximum.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Maximum.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.maximum: Element-wise maximum of array elements.
+    
+    Compares two arrays element-wise and returns a new array containing
+    the element-wise maxima. If one of the elements being compared is NaN,
+    then that element is returned.
+    
+    This is different from numpy.max which returns a single maximum value.
+-/
+def numpy_maximum {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.maximum returns a vector where each element is the maximum
+    of the corresponding elements from x1 and x2.
+    
+    Precondition: True (no special preconditions for element-wise maximum)
+    Postcondition: For all indices i, result[i] = max(x1[i], x2[i])
+-/
+theorem numpy_maximum_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_maximum x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = max (x1.get i) (x2.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Mean.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Mean.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.mean: Arithmetic mean of array elements.
+    
+    Computes the arithmetic mean (average) of all elements in the array.
+    Requires a non-empty array since division by zero is undefined.
+    
+    The mean is calculated as the sum of all elements divided by the
+    number of elements.
+-/
+def numpy_mean (a : Vector Float (n + 1)) : Id Float :=
+  sorry
+
+/-- Specification: numpy.mean returns the arithmetic mean of all elements.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: result = (sum of all elements) / (number of elements)
+-/
+theorem numpy_mean_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_mean a
+    ⦃⇓result => result = (List.sum (a.toList)) / Float.ofNat (n + 1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Min.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Min.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.min: Minimum value in array.
+    
+    Returns the minimum value among all elements in the array.
+    Requires a non-empty array since there is no minimum of an empty set.
+    
+    This is a reduction operation that finds the smallest value in the array.
+-/
+def numpy_min (a : Vector Float (n + 1)) : Id Float :=
+  sorry
+
+/-- Specification: numpy.min returns the minimum element in the vector.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: result is the minimum value and is an element of the vector
+-/
+theorem numpy_min_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_min a
+    ⦃⇓result => (∃ i : Fin (n + 1), a.get i = result) ∧ 
+                (∀ i : Fin (n + 1), result ≤ a.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Minimum.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Minimum.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.minimum: Element-wise minimum of array elements.
+    
+    Compares two arrays element-wise and returns a new array containing
+    the element-wise minima. If one of the elements being compared is NaN,
+    then that element is returned.
+    
+    This is different from numpy.min which returns a single minimum value.
+-/
+def numpy_minimum {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.minimum returns a vector where each element is the minimum
+    of the corresponding elements from x1 and x2.
+    
+    Precondition: True (no special preconditions for element-wise minimum)
+    Postcondition: For all indices i, result[i] = min(x1[i], x2[i])
+-/
+theorem numpy_minimum_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_minimum x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = min (x1.get i) (x2.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Multiply.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Multiply.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.multiply: Multiply arguments element-wise.
+    
+    Multiplies arguments element-wise. If the arrays have the same shape,
+    each element of the result is the product of the corresponding elements
+    from the input arrays.
+    
+    This is equivalent to x1 * x2 in terms of array broadcasting.
+-/
+def numpy_multiply {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.multiply returns a vector where each element is the product
+    of the corresponding elements from x1 and x2.
+    
+    Precondition: True (no special preconditions for basic multiplication)
+    Postcondition: For all indices i, result[i] = x1[i] * x2[i]
+-/
+theorem numpy_multiply_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_multiply x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = x1.get i * x2.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Power.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Power.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.power: First array elements raised to powers from second array, element-wise.
+    
+    Raise each base in x1 to the positionally-corresponding power in x2.
+    x1 and x2 must be broadcastable to the same shape.
+    
+    This is equivalent to x1 ** x2 in terms of array operations.
+-/
+def numpy_power {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.power returns a vector where each element is x1[i] raised
+    to the power of x2[i].
+    
+    Precondition: True (no special preconditions for basic power operation)
+    Postcondition: For all indices i, result[i] = x1[i] ^ x2[i]
+-/
+theorem numpy_power_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_power x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = x1.get i ^ x2.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Prod.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Prod.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.prod: Product of array elements.
+    
+    Returns the product of all elements in the array. For empty arrays,
+    returns 1 as the identity element of multiplication.
+    
+    This is a reduction operation that multiplies all values in the
+    array into a single scalar result.
+-/
+def numpy_prod {n : Nat} (a : Vector Float n) : Id Float :=
+  sorry
+
+/-- Specification: numpy.prod returns the product of all elements in the vector.
+    
+    Precondition: True (works for any vector, including empty)
+    Postcondition: result = product of all elements (1 for empty vector)
+-/
+theorem numpy_prod_spec {n : Nat} (a : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_prod a
+    ⦃⇓result => result = (a.toList.foldl (· * ·) 1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Reshape.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Reshape.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.reshape: Gives a new shape to an array without changing its data.
+    
+    For 1D arrays, reshape can only produce shapes with the same total
+    number of elements. The most common 1D reshape operations are:
+    - Reshape to a different 1D shape (must have same size)
+    - Special case: -1 in shape means "infer this dimension"
+    
+    This simplified version handles 1D to 1D reshaping only.
+-/
+def numpy_reshape {n m : Nat} (a : Vector Float n) (h_size : n = m) : Id (Vector Float m) :=
+  sorry
+
+/-- Specification: numpy.reshape returns a vector with new shape but same elements.
+    
+    Precondition: The new shape must have the same total number of elements
+    Postcondition: Elements appear in the same order in the reshaped array
+-/
+theorem numpy_reshape_spec {n m : Nat} (a : Vector Float n) (h_size : n = m) :
+    ⦃⌜n = m⌝⦄
+    numpy_reshape a h_size
+    ⦃⇓result => ∀ i : Fin m, result.get i = a.get (i.cast h_size.symm)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Sign.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Sign.lean
@@ -1,0 +1,33 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.sign: Returns an element-wise indication of the sign of a number.
+    
+    Returns -1 if x < 0, 0 if x == 0, 1 if x > 0.
+    For complex numbers, this is defined as sign(x) = x / |x|.
+    For real numbers, this returns the standard signum function.
+    
+    Returns an array of the same shape as x, containing the signs.
+-/
+def numpy_sign {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.sign returns a vector where each element indicates
+    the sign of the corresponding element in x.
+    
+    Precondition: True (no special preconditions for sign function)
+    Postcondition: For all indices i:
+      - result[i] = -1 if x[i] < 0
+      - result[i] = 0 if x[i] = 0  
+      - result[i] = 1 if x[i] > 0
+-/
+theorem numpy_sign_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_sign x
+    ⦃⇓result => ∀ i : Fin n, 
+      (x.get i < 0 → result.get i = -1) ∧
+      (x.get i = 0 → result.get i = 0) ∧
+      (x.get i > 0 → result.get i = 1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Sin.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Sin.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.sin: Trigonometric sine, element-wise.
+    
+    The sine is one of the fundamental functions of trigonometry.
+    For a real number x interpreted as an angle in radians, sin(x)
+    gives the y-coordinate of the point on the unit circle.
+    
+    Returns an array of the same shape as x, containing the sine of each element.
+-/
+def numpy_sin {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.sin returns a vector where each element is the sine
+    of the corresponding element in x (interpreted as radians).
+    
+    Precondition: True (no special preconditions for sine)
+    Postcondition: For all indices i, result[i] = Float.sin x[i]
+-/
+theorem numpy_sin_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_sin x
+    ⦃⇓result => ∀ i : Fin n, result.get i = Float.sin (x.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Sort.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Sort.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.sort: Return a sorted copy of an array.
+    
+    Returns a new array with the same elements sorted in ascending order.
+    The original array is not modified.
+    
+    This function performs a stable sort on the array elements.
+-/
+def numpy_sort (a : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.sort returns a sorted permutation of the input.
+    
+    Precondition: True
+    Postcondition: Result is sorted and is a permutation of the input
+-/
+theorem numpy_sort_spec (a : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_sort a
+    ⦃⇓result => (∀ i j : Fin n, i < j → result.get i ≤ result.get j) ∧
+                (∀ x : Float, (result.toList.count x) = (a.toList.count x))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Split.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Split.lean
@@ -1,0 +1,37 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Split an array into multiple sub-arrays of equal size.
+    
+    This simplified version of numpy.split handles the case where we split
+    a 1D array into N equal parts. The array size must be divisible by N.
+    
+    For simplicity, we return a list of vectors rather than a vector of vectors.
+-/
+def numpy_split {n k : Nat} (arr : Vector Float (k * n)) (sections : Nat) 
+    (h : sections = k) : Id (List (Vector Float n)) :=
+  sorry
+
+/-- Specification: numpy_split divides array into equal-sized sub-arrays.
+    
+    When splitting an array of size k*n into k sections, each sub-array
+    has exactly n elements. The i-th sub-array contains elements from
+    positions i*n to (i+1)*n-1 of the original array.
+-/
+theorem numpy_split_spec {n k : Nat} (arr : Vector Float (k * n)) 
+    (h : k > 0) :
+    ⦃⌜k > 0⌝⦄
+    numpy_split arr k rfl
+    ⦃⇓result => result.length = k ∧ 
+                ∀ i : Fin k, ∃ sub ∈ result, 
+                  ∀ j : Fin n, sub.get j = arr.get ⟨i.val * n + j.val, by
+                    have h1 : i.val < k := i.isLt
+                    have h2 : j.val < n := j.isLt
+                    calc i.val * n + j.val
+                      < i.val * n + n := Nat.add_lt_add_left h2 _
+                      _ = (i.val + 1) * n := by rw [Nat.add_mul, Nat.one_mul]
+                      _ ≤ k * n := Nat.mul_le_mul_right _ (Nat.succ_le_of_lt h1)
+                  ⟩⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Sqrt.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Sqrt.lean
@@ -1,0 +1,28 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.sqrt: Return the non-negative square-root of an array, element-wise.
+
+    Computes the principal square root of each element in the input array.
+    For negative input elements, the result is NaN (Not a Number).
+
+    An array of the same shape as x, containing the positive square-root
+    of each element in x.
+-/
+def numpy_sqrt {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.sqrt returns a vector where each element is the
+    non-negative square root of the corresponding element in x.
+
+    Precondition: True (handles negative values by returning NaN)
+    Postcondition: For all indices i, if x[i] ≥ 0 then result[i]² = x[i] and result[i] ≥ 0
+-/
+theorem numpy_sqrt_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_sqrt x
+    ⦃⇓result => ∀ i : Fin n,
+      (x.get i ≥ 0 → result.get i ^ 2 = x.get i ∧ result.get i ≥ 0)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Square.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Square.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.square: Return the element-wise square of the input.
+    
+    Computes the square of each element in the input array.
+    This is equivalent to x * x, element-wise.
+    
+    Returns an array of the same shape as x, containing the element-wise squares.
+-/
+def numpy_square {n : Nat} (x : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.square returns a vector where each element is the square
+    of the corresponding element in x.
+    
+    Precondition: True (no special preconditions for squaring)
+    Postcondition: For all indices i, result[i] = x[i] * x[i]
+-/
+theorem numpy_square_spec {n : Nat} (x : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_square x
+    ⦃⇓result => ∀ i : Fin n, result.get i = x.get i * x.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Stack.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Stack.lean
@@ -1,0 +1,33 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.stack: Join a sequence of arrays along a new axis.
+    
+    Stack takes multiple arrays and joins them along a new axis.
+    For 1D arrays, stacking creates a 2D array where each input
+    array becomes a row (axis=0) or column (axis=1).
+    
+    Since we're focusing on 1D operations, we'll note that stack
+    inherently creates higher-dimensional arrays, so we'll provide
+    a specification comment but mark it as out of scope for 1D-only
+    implementations.
+-/
+-- Note: Stack creates 2D arrays from 1D inputs, so we skip implementation
+-- for purely 1D operations. Here's what the signature would look like:
+-- def numpy_stack {n k : Nat} (arrays : Vector (Vector Float n) k) (axis : Nat) : 
+--     Id (Array2D Float) := sorry
+
+/-
+Specification comment for numpy.stack (not implemented for 1D-only):
+
+Stack would take k arrays of length n and create:
+- If axis=0: a k×n array where each input is a row
+- If axis=1: a n×k array where each input is a column
+
+Since this creates 2D arrays, it's outside our 1D-only scope.
+-/
+
+/-- Placeholder to indicate stack is not implemented for 1D-only scope -/
+def numpy_stack_not_implemented : Unit := ()

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Std.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Std.lean
@@ -1,0 +1,29 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.std: Standard deviation of array elements.
+    
+    Computes the standard deviation of all elements in the array.
+    Requires a non-empty array since variance calculation needs the mean.
+    
+    The standard deviation is the square root of the variance, which measures
+    the spread of the data around the mean.
+-/
+def numpy_std (a : Vector Float (n + 1)) : Id Float :=
+  sorry
+
+/-- Specification: numpy.std returns the standard deviation of all elements.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: result = sqrt(variance) where variance = mean((x - mean)²)
+-/
+theorem numpy_std_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_std a
+    ⦃⇓result => 
+      let mean := (List.sum (a.toList)) / Float.ofNat (n + 1)
+      let variance := (List.sum (a.toList.map (fun x => (x - mean) * (x - mean)))) / Float.ofNat (n + 1)
+      result = Float.sqrt variance⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Subtract.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Subtract.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.subtract: Subtract arguments, element-wise.
+    
+    Subtracts arguments element-wise. If the arrays have the same shape,
+    each element of the result is the difference of the corresponding elements
+    from the input arrays.
+    
+    This is equivalent to x1 - x2 in terms of array broadcasting.
+-/
+def numpy_subtract {n : Nat} (x1 x2 : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.subtract returns a vector where each element is the difference
+    of the corresponding elements from x1 and x2.
+    
+    Precondition: True (no special preconditions for basic subtraction)
+    Postcondition: For all indices i, result[i] = x1[i] - x2[i]
+-/
+theorem numpy_subtract_spec {n : Nat} (x1 x2 : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_subtract x1 x2
+    ⦃⇓result => ∀ i : Fin n, result.get i = x1.get i - x2.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Sum.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Sum.lean
@@ -1,0 +1,26 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.sum: Sum of array elements.
+    
+    Returns the sum of all elements in the array. For empty arrays,
+    returns 0 as the identity element of addition.
+    
+    This is a reduction operation that aggregates all values in the
+    array into a single scalar result.
+-/
+def numpy_sum {n : Nat} (a : Vector Float n) : Id Float :=
+  sorry
+
+/-- Specification: numpy.sum returns the sum of all elements in the vector.
+    
+    Precondition: True (works for any vector, including empty)
+    Postcondition: result = sum of all elements (0 for empty vector)
+-/
+theorem numpy_sum_spec {n : Nat} (a : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_sum a
+    ⦃⇓result => result = (List.sum (a.toList))⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Transpose.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Transpose.lean
@@ -1,0 +1,27 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.transpose: Reverse or permute the axes of an array.
+    
+    For 1D arrays, this is a no-op - it returns the input array unchanged.
+    This reflects numpy's behavior where transposing a 1D array has no effect
+    since there's only one axis.
+    
+    For higher dimensions, transpose would swap axes, but we focus on the
+    1D case here as requested.
+-/
+def numpy_transpose {n : Nat} (a : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.transpose returns the input vector unchanged for 1D arrays.
+    
+    Precondition: True (no special preconditions for 1D transpose)
+    Postcondition: The result is identical to the input vector
+-/
+theorem numpy_transpose_spec {n : Nat} (a : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_transpose a
+    ⦃⇓result => result = a⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Var.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Var.lean
@@ -1,0 +1,28 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.var: Variance of array elements.
+    
+    Computes the variance of all elements in the array.
+    Requires a non-empty array since variance calculation needs the mean.
+    
+    The variance measures how spread out the data is from the mean.
+    It is calculated as the average of the squared differences from the mean.
+-/
+def numpy_var (a : Vector Float (n + 1)) : Id Float :=
+  sorry
+
+/-- Specification: numpy.var returns the variance of all elements.
+    
+    Precondition: True (non-empty constraint is in the type)
+    Postcondition: result = mean((x - mean)²)
+-/
+theorem numpy_var_spec (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    numpy_var a
+    ⦃⇓result => 
+      let mean := (List.sum (a.toList)) / Float.ofNat (n + 1)
+      result = (List.sum (a.toList.map (fun x => (x - mean) * (x - mean)))) / Float.ofNat (n + 1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_from_doc/Numpy_Where.lean
+++ b/DafnySpecs/dfy_syntax_from_doc/Numpy_Where.lean
@@ -1,0 +1,25 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- numpy.where: Return elements chosen from x or y depending on condition.
+    
+    For each element, returns x[i] if condition[i] is true, else y[i].
+    All three arrays must have the same shape.
+    
+    This function enables conditional selection between two arrays.
+-/
+def numpy_where (condition : Vector Bool n) (x : Vector Float n) (y : Vector Float n) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: numpy.where performs element-wise conditional selection.
+    
+    Precondition: True (same-size constraint is in the type)
+    Postcondition: Each element is selected from x or y based on condition
+-/
+theorem numpy_where_spec (condition : Vector Bool n) (x : Vector Float n) (y : Vector Float n) :
+    ⦃⌜True⌝⦄
+    numpy_where condition x y
+    ⦃⇓result => ∀ i : Fin n, result.get i = if condition.get i then x.get i else y.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpAbs.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpAbs.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for absolute value -/
+def AbsInt (x : Int) : Int := if x < 0 then -x else x
+
+/-- Computes the absolute value of each element in a vector -/
+def abs {n : Nat} (v : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: abs returns a vector of the same size with absolute values -/
+theorem abs_spec {n : Nat} (v : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    abs v
+    ⦃⇓res => (∀ i : Fin (n + 1), res.get i = AbsInt (v.get i)) ∧
+             (∀ i : Fin (n + 1), res.get i ≥ 0)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpAdd.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpAdd.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Adds two vectors element-wise -/
+def add {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: add returns a vector with element-wise sums -/
+theorem add_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    add a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = a.get i + b.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpArange.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpArange.lean
@@ -1,0 +1,21 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns evenly spaced values within a given interval as a vector of known size -/
+def arange (n : Nat) (start stop step : Float) : Id (Vector Float n) :=
+  sorry
+
+/-- Specification: arange returns a vector of evenly spaced values -/
+theorem arange_spec (n : Nat) (start stop step : Float) 
+    (h1 : if step < 0.0 then start > stop else start < stop)
+    (h2 : step ≠ 0.0)
+    (h3 : n = ((stop - start)/step).floor.toUInt64.toNat) :
+    ⦃⌜(if step < 0.0 then start > stop else start < stop) ∧ step ≠ 0.0 ∧ 
+      n = ((stop - start)/step).floor.toUInt64.toNat⌝⦄
+    arange n start stop step
+    ⦃⇓ret => (∀ h0 : 0 < n, ret.get ⟨0, h0⟩ = start) ∧
+             ∀ i : Nat, ∀ hi : i + 1 < n, 
+               ret.get ⟨i + 1, hi⟩ - ret.get ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ = step⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpArgmax.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpArgmax.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the index of the maximum value in a vector (first occurrence) -/
+def argmax {n : Nat} (arr : Vector Float n) (h : n > 0) : Id (Fin n) :=
+  sorry
+
+/-- Specification: argmax returns the index of the first maximum element -/
+theorem argmax_spec {n : Nat} (arr : Vector Float n) (h : n > 0) :
+    ⦃⌜n > 0⌝⦄
+    argmax arr h
+    ⦃⇓ret => (∀ i : Fin n, i < ret → arr.get ret > arr.get i) ∧
+             (∀ i : Fin n, ret < i → arr.get ret ≥ arr.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpBitwiseAnd.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpBitwiseAnd.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for bitwise AND of integers -/
+def BitwiseAndInt (x y : Int) : Int :=
+  sorry
+
+/-- Performs bitwise AND on two vectors element-wise -/
+def bitwiseAnd {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: bitwiseAnd returns a vector with element-wise bitwise AND -/
+theorem bitwiseAnd_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    bitwiseAnd a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = BitwiseAndInt (a.get i) (b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpBitwiseOr.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpBitwiseOr.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for bitwise OR of integers -/
+def BitwiseOrInt (x y : Int) : Int :=
+  sorry
+
+/-- Performs bitwise OR on two vectors element-wise -/
+def bitwiseOr {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: bitwiseOr returns a vector with element-wise bitwise OR -/
+theorem bitwiseOr_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    bitwiseOr a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = BitwiseOrInt (a.get i) (b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpBitwiseXor.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpBitwiseXor.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function for bitwise XOR of integers -/
+def BitwiseXorInt (x y : Int) : Int :=
+  sorry
+
+/-- Performs bitwise XOR on two vectors element-wise -/
+def bitwiseXor {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: bitwiseXor returns a vector with element-wise bitwise XOR -/
+theorem bitwiseXor_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    bitwiseXor a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = BitwiseXorInt (a.get i) (b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpCenter.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpCenter.lean
@@ -1,0 +1,20 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Centers each string in a vector within a string of specified width -/
+def center {n : Nat} (input : Vector String n) (width : Nat) : Id (Vector String n) :=
+  sorry
+
+/-- Specification: center returns a vector with centered strings -/
+theorem center_spec {n : Nat} (input : Vector String n) (width : Nat) 
+    (h : ∀ i : Fin n, (input.get i).length ≥ 1) :
+    ⦃⌜∀ i : Fin n, (input.get i).length ≥ 1⌝⦄
+    center input width
+    ⦃⇓r => ∀ i : Fin n, 
+           if (input.get i).length > width then 
+             (r.get i).length = (input.get i).length 
+           else 
+             (r.get i).length = width⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpCopy.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpCopy.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns a copy of the given vector -/
+def copy {n : Nat} (v : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: copy returns a vector with the same length and elements -/
+theorem copy_spec {n : Nat} (v : Vector Int n) :
+    ⦃⌜True⌝⦄
+    copy v
+    ⦃⇓ret => ∀ i : Fin n, ret.get i = v.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpCumProd.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpCumProd.lean
@@ -1,0 +1,18 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Computes the cumulative product of vector elements -/
+def cumProd {n : Nat} (a : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: cumProd returns a vector with cumulative products -/
+theorem cumProd_spec {n : Nat} (a : Vector Int n) (h : n > 0) :
+    ⦃⌜n > 0⌝⦄
+    cumProd a
+    ⦃⇓res => (res.get ⟨0, h⟩ = a.get ⟨0, h⟩) ∧
+             (∀ i : Nat, ∀ hi : i + 1 < n, 
+               res.get ⟨i + 1, hi⟩ = res.get ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ * 
+                                      a.get ⟨i + 1, hi⟩)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpCumSum.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpCumSum.lean
@@ -1,0 +1,18 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Computes the cumulative sum of vector elements -/
+def cumSum {n : Nat} (a : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: cumSum returns a vector with cumulative sums -/
+theorem cumSum_spec {n : Nat} (a : Vector Int n) (h : n > 0) :
+    ⦃⌜n > 0⌝⦄
+    cumSum a
+    ⦃⇓res => (res.get ⟨0, h⟩ = a.get ⟨0, h⟩) ∧
+             (∀ i : Nat, ∀ hi : i + 1 < n, 
+               res.get ⟨i + 1, hi⟩ = res.get ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ + 
+                                     a.get ⟨i + 1, hi⟩)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpEqual.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two vectors element-wise for equality -/
+def equal {n : Nat} (a b : Vector Int n) : Id (Vector Bool n) :=
+  sorry
+
+/-- Specification: equal returns a vector of booleans indicating element-wise equality -/
+theorem equal_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    equal a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = (a.get i = b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpFlatten.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpFlatten.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Flattens a 2D vector (represented as Vector of Vectors) into a 1D vector -/
+def flatten2 {rows cols : Nat} (mat : Vector (Vector Int cols) rows) : Id (Vector Int (rows * cols)) :=
+  sorry
+
+/-- Specification: flatten2 returns a 1D vector with all elements from the 2D vector in row-major order -/
+theorem flatten2_spec {rows cols : Nat} (mat : Vector (Vector Int cols) rows) 
+    (h1 : rows > 0) 
+    (h2 : cols > 0) :
+    ⦃⌜rows > 0 ∧ cols > 0⌝⦄
+    flatten2 mat
+    ⦃⇓ret => ∀ (i : Fin rows) (j : Fin cols), 
+             ∃ (idx : Fin (rows * cols)) (hidx : idx.val = i.val * cols + j.val),
+             ret.get idx = (mat.get i).get j⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpFloorDivide.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpFloorDivide.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Element-wise floor division on two vectors -/
+def floorDivide {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: floorDivide returns a vector with element-wise integer division -/
+theorem floorDivide_spec {n : Nat} (a b : Vector Int n) 
+    (h_nonzero : ∀ i : Fin n, b.get i ≠ 0) :
+    ⦃⌜∀ i : Fin n, b.get i ≠ 0⌝⦄
+    floorDivide a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = a.get i / b.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpGreater.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpGreater.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two vectors element-wise for greater than -/
+def greater {n : Nat} (a b : Vector Int n) : Id (Vector Bool n) :=
+  sorry
+
+/-- Specification: greater returns a vector of booleans indicating element-wise comparison -/
+theorem greater_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    greater a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = (a.get i > b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpGreaterEqual.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpGreaterEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two vectors element-wise for greater than or equal -/
+def greaterEqual {n : Nat} (a b : Vector Int n) : Id (Vector Bool n) :=
+  sorry
+
+/-- Specification: greaterEqual returns a vector of booleans indicating element-wise comparison -/
+theorem greaterEqual_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    greaterEqual a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = (a.get i ≥ b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpLeftShift.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpLeftShift.lean
@@ -1,0 +1,20 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Left shift operation on integers -/
+def shiftLeft (n : Int) (shift : Nat) : Int :=
+  sorry  -- This would be implemented using bitwise operations
+
+/-- Element-wise left shift operation on two vectors -/
+def leftShift {n : Nat} (a : Vector Int n) (b : Vector Nat n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: leftShift returns a vector with element-wise left shift -/
+theorem leftShift_spec {n : Nat} (a : Vector Int n) (b : Vector Nat n) 
+    (h_bound : ∀ i : Fin n, b.get i < 64) :
+    ⦃⌜∀ i : Fin n, b.get i < 64⌝⦄
+    leftShift a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = shiftLeft (a.get i) (b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpLess.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpLess.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two vectors element-wise for less than -/
+def less {n : Nat} (a b : Vector Int n) : Id (Vector Bool n) :=
+  sorry
+
+/-- Specification: less returns a vector of booleans indicating element-wise comparison -/
+theorem less_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    less a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = (a.get i < b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpLessEqual.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpLessEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two vectors element-wise for less than or equal -/
+def lessEqual {n : Nat} (a b : Vector Int n) : Id (Vector Bool n) :=
+  sorry
+
+/-- Specification: lessEqual returns a vector of booleans indicating element-wise comparison -/
+theorem lessEqual_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    lessEqual a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = (a.get i ≤ b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpMax.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpMax.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Finds the maximum element in a vector -/
+def max {n : Nat} (a : Vector Int (n + 1)) : Id Int :=
+  sorry
+
+/-- Specification: max returns the maximum element from a non-empty vector -/
+theorem max_spec {n : Nat} (a : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    max a
+    ⦃⇓res => ∃ i : Fin (n + 1), res = a.get i ∧
+             ∀ j : Fin (n + 1), a.get j ≤ res⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpMin.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpMin.lean
@@ -1,0 +1,16 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Finds the minimum element in a vector -/
+def min {n : Nat} (a : Vector Int (n + 1)) : Id Int :=
+  sorry
+
+/-- Specification: min returns the minimum element from a non-empty vector -/
+theorem min_spec {n : Nat} (a : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    min a
+    ⦃⇓res => ∃ i : Fin (n + 1), res = a.get i ∧
+             ∀ j : Fin (n + 1), res ≤ a.get j⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpMultiply.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpMultiply.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Multiplies two vectors element-wise -/
+def multiply {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: multiply returns a vector of the same size with element-wise products -/
+theorem multiply_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    multiply a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = a.get i * b.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpNotEqual.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpNotEqual.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Compares two vectors element-wise for inequality -/
+def notEqual {n : Nat} (a b : Vector Int n) : Id (Vector Bool n) :=
+  sorry
+
+/-- Specification: notEqual returns a vector of booleans indicating element-wise comparison -/
+theorem notEqual_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    notEqual a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = (a.get i ≠ b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpPower.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpPower.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Power function for integers -/
+def pow (base : Int) (exp : Nat) : Int :=
+  sorry  -- This would be implemented as integer power
+
+/-- Element-wise power operation on two vectors -/
+def power {n : Nat} (a : Vector Int n) (b : Vector Nat n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: power returns a vector with element-wise exponentiation -/
+theorem power_spec {n : Nat} (a : Vector Int n) (b : Vector Nat n) :
+    ⦃⌜True⌝⦄
+    power a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = pow (a.get i) (b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpProd.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpProd.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function to compute product of vector elements from start to endPos -/
+def ProdVector {n : Nat} (v : Vector Int n) (start : Nat) (endPos : Nat) : Int :=
+  sorry
+
+/-- Computes the product of all elements in a vector -/
+def prod {n : Nat} (v : Vector Int n) : Id Int :=
+  sorry
+
+/-- Specification: prod returns the product of all vector elements -/
+theorem prod_spec {n : Nat} (v : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    prod v
+    ⦃⇓res => res = ProdVector v 0 (n + 1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpRightShift.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpRightShift.lean
@@ -1,0 +1,20 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Right shift operation on integers -/
+def shiftRight (n : Int) (shift : Nat) : Int :=
+  sorry  -- This would be implemented using bitwise operations
+
+/-- Element-wise right shift operation on two vectors -/
+def rightShift {n : Nat} (a : Vector Int n) (b : Vector Nat n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: rightShift returns a vector with element-wise right shift -/
+theorem rightShift_spec {n : Nat} (a : Vector Int n) (b : Vector Nat n) 
+    (h_bound : ∀ i : Fin n, b.get i < 64) :
+    ⦃⌜∀ i : Fin n, b.get i < 64⌝⦄
+    rightShift a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = shiftRight (a.get i) (b.get i)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpSign.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpSign.lean
@@ -1,0 +1,18 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the sign of each element in a vector -/
+def sign {n : Nat} (a : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: sign returns a vector with -1, 0, or 1 based on element signs -/
+theorem sign_spec {n : Nat} (a : Vector Int n) :
+    ⦃⌜True⌝⦄
+    sign a
+    ⦃⇓res => ∀ i : Fin n, 
+             (a.get i > 0 → res.get i = 1) ∧
+             (a.get i = 0 → res.get i = 0) ∧
+             (a.get i < 0 → res.get i = -1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpSquare.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpSquare.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the element-wise square of the input vector -/
+def square {n : Nat} (v : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: square returns a vector of the same size with squared elements -/
+theorem square_spec {n : Nat} (v : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    square v
+    ⦃⇓ret => ∀ i : Fin (n + 1), ret.get i = v.get i * v.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpSubtract.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpSubtract.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Subtracts two vectors element-wise -/
+def subtract {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: subtract returns a vector of the same size with element-wise differences -/
+theorem subtract_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    subtract a b
+    ⦃⇓res => ∀ i : Fin n, res.get i = a.get i - b.get i⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpSum.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpSum.lean
@@ -1,0 +1,19 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Helper function to compute sum of vector elements from start to endPos -/
+def SumVector {n : Nat} (v : Vector Int n) (start : Nat) (endPos : Nat) : Int :=
+  sorry
+
+/-- Computes the sum of all elements in a vector -/
+def sum {n : Nat} (v : Vector Int n) : Id Int :=
+  sorry
+
+/-- Specification: sum returns the sum of all vector elements -/
+theorem sum_spec {n : Nat} (v : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    sum v
+    ⦃⇓res => res = SumVector v 0 (n + 1)⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/NpZeros.lean
+++ b/DafnySpecs/dfy_syntax_vector/NpZeros.lean
@@ -1,0 +1,15 @@
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Creates a vector of zeros with the given size -/
+def zeros (n : Nat) : Id (Vector Int n) :=
+  sorry
+
+/-- Specification: zeros returns a vector of zeros with the specified size -/
+theorem zeros_spec (n : Nat) :
+    ⦃⌜True⌝⦄
+    zeros n
+    ⦃⇓ret => ∀ i : Fin n, ret.get i = 0⦄ := by
+  sorry

--- a/DafnySpecs/dfy_syntax_vector/PIPELINE.md
+++ b/DafnySpecs/dfy_syntax_vector/PIPELINE.md
@@ -1,0 +1,452 @@
+# Pipeline for Generating Lean 4 Specifications from NumPy Documentation
+
+## Overview
+
+This document provides a systematic process for generating Vector-based Lean 4 specifications with Hoare triple syntax from NumPy function documentation and source code. The pipeline produces formal specifications that capture the mathematical properties of NumPy operations.
+
+## Essential Concepts
+
+### 1. Hoare Triple Syntax in Lean 4
+
+The new syntax uses special brackets for pre/post conditions:
+```lean
+⦃⌜precondition⌝⦄ function ⦃⇓result => postcondition⦄
+```
+
+- `⦃⌜...⌝⦄` - Precondition wrapped in special brackets
+- `⦃⇓result => ...⦄` - Postcondition with bound result variable
+- Always end theorems with `:= by sorry` during specification phase
+
+### 2. Array to Vector Transformation Rules
+
+| Array Pattern | Vector Pattern |
+|--------------|----------------|
+| `Array T` | `Vector T n` |
+| `a : Array Int` | `{n : Nat} (a : Vector Int n)` |
+| `(h : a.size = b.size)` | Remove (enforced by type) |
+| `a.size > 0` | Use `Vector T (n + 1)` |
+| `∀ i (hi : i < a.size)` | `∀ i : Fin n` |
+| `a[i]'hi` | `a.get i` |
+| `∃ hr : res.size = a.size` | Remove (types match) |
+
+## Complete Examples
+
+### Example 1: Binary Operation (Addition)
+
+**Array Version:**
+```lean
+def add (a b : Array Int): Id (Array Int) :=
+  sorry
+
+theorem add_spec (a b : Array Int) (h : a.size = b.size) :
+    ⦃⌜a.size = b.size⌝⦄
+    add a b
+    ⦃⇓r => ∃ hr : r.size = a.size, ∀ i (hi : i < r.size), r[i] = a[i] + b[i]⦄ := by
+  sorry
+```
+
+**Vector Version:**
+```lean
+def add {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+theorem add_spec {n : Nat} (a b : Vector Int n) :
+    ⦃⌜True⌝⦄
+    add a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = a.get i + b.get i⦄ := by
+  sorry
+```
+
+### Example 2: Unary Operation Requiring Non-empty (Maximum)
+
+**Array Version:**
+```lean
+def max (a : Array Int) : Id Int :=
+  sorry
+
+theorem max_spec (a : Array Int) (h : a.size > 0) :
+    ⦃⌜a.size > 0⌝⦄
+    max a
+    ⦃⇓res => ∃ i : Nat, ∃ hi : i < a.size, res = a[i]'hi ∧
+             ∀ j : Nat, ∀ hj : j < a.size, a[j]'hj ≤ res⦄ := by
+  sorry
+```
+
+**Vector Version:**
+```lean
+def max {n : Nat} (a : Vector Int (n + 1)) : Id Int :=
+  sorry
+
+theorem max_spec {n : Nat} (a : Vector Int (n + 1)) :
+    ⦃⌜True⌝⦄
+    max a
+    ⦃⇓res => ∃ i : Fin (n + 1), res = a.get i ∧
+             ∀ j : Fin (n + 1), a.get j ≤ res⦄ := by
+  sorry
+```
+
+## Step-by-Step Workflow
+
+### 1. Initial Setup
+```bash
+mkdir -p DafnySpecs/dfy_syntax_from_doc
+```
+
+### 2. File-by-File Conversion Process
+
+For each file:
+
+1. **Read the original Array version**
+   ```lean
+   -- Identify: function signature, preconditions, postconditions
+   ```
+
+2. **Create the Vector version header**
+   ```lean
+   import Std.Do.Triple
+   import Std.Tactic.Do
+   
+   open Std.Do
+   ```
+
+3. **Transform the function signature**
+   - Add `{n : Nat}` parameter for vector size
+   - Replace `Array T` with `Vector T n`
+   - For non-empty requirements, use `Vector T (n + 1)`
+   - Remove size equality parameters
+
+4. **Transform the specification**
+   - Simplify preconditions (usually to `⌜True⌝`)
+   - Remove existential size proofs
+   - Replace index types with `Fin n`
+   - Use `.get` for element access
+
+5. **Compile and verify**
+   ```bash
+   lake build  # Check for compilation errors
+   ```
+
+### 3. Common Patterns
+
+#### Binary Operations (Equal Size)
+```lean
+def op {n : Nat} (a b : Vector T n) : Id (Vector R n) :=
+  sorry
+
+theorem op_spec {n : Nat} (a b : Vector T n) :
+    ⦃⌜True⌝⦄
+    op a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = f (a.get i) (b.get i)⦄ := by
+  sorry
+```
+
+#### Operations with Non-zero Preconditions
+```lean
+def divide {n : Nat} (a b : Vector Int n) : Id (Vector Int n) :=
+  sorry
+
+theorem divide_spec {n : Nat} (a b : Vector Int n) 
+    (h_nonzero : ∀ i : Fin n, b.get i ≠ 0) :
+    ⦃⌜∀ i : Fin n, b.get i ≠ 0⌝⦄
+    divide a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = a.get i / b.get i⦄ := by
+  sorry
+```
+
+#### Index-returning Operations
+```lean
+def argmax {n : Nat} (a : Vector Float (n + 1)) : Id (Fin (n + 1)) :=
+  sorry
+
+theorem argmax_spec {n : Nat} (a : Vector Float (n + 1)) :
+    ⦃⌜True⌝⦄
+    argmax a
+    ⦃⇓idx => a.get idx = max a ∧ 
+            ∀ j : Fin (n + 1), j < idx → a.get j < a.get idx⦄ := by
+  sorry
+```
+
+## Critical Success Factors
+
+### 1. Type-Level Size Management
+- Use implicit `{n : Nat}` parameters
+- Let Lean infer sizes when possible
+- Use `(n + 1)` pattern for non-empty constraints
+
+### 2. Proof Simplification
+- Vector types eliminate size equality proofs
+- `Fin n` eliminates bounds checking proofs
+- Focus specifications on actual behavior, not size management
+
+### 3. Compilation Verification
+- **Always** check compilation after each file
+- Fix errors immediately before proceeding
+- Common fixes:
+  - Missing parentheses around array accesses
+  - Incorrect proof term transformations
+  - Type mismatches in index operations
+
+### 4. Special Cases
+
+#### 2D Arrays
+```lean
+-- Use Vector of Vectors
+def flatten {rows cols : Nat} 
+    (mat : Vector (Vector Int cols) rows) : 
+    Id (Vector Int (rows * cols)) :=
+  sorry
+```
+
+#### Dynamic Size Computation
+```lean
+-- Add size as parameter with constraint
+def arange {n : Nat} (start stop step : Float) : Id (Vector Float n) :=
+  sorry
+
+theorem arange_spec {n : Nat} (start stop step : Float) 
+    (h_size : n = ((stop - start)/step).floor.toUInt64.toNat) :
+    ⦃⌜n = ((stop - start)/step).floor.toUInt64.toNat⌝⦄
+    arange start stop step
+    ⦃⇓v => v.get ⟨0, sorry⟩ = start ∧ ...⦄ := by
+  sorry
+```
+
+## Common Pitfalls and Solutions
+
+1. **Forgetting to wrap array accesses in parentheses**
+   - Wrong: `a[i]'proof + b[i]'proof`
+   - Right: `(a[i]'proof) + (b[i]'proof)`
+
+2. **Using wrong index types**
+   - Wrong: `∀ i : Nat, i < n → ...`
+   - Right: `∀ i : Fin n, ...`
+
+3. **Keeping unnecessary size proofs**
+   - Wrong: `∃ hr : r.size = a.size, ...`
+   - Right: Just use the postcondition directly
+
+4. **Complex index proof terms**
+   - Wrong: `a[i]'(hr ▸ h ▸ hi)`
+   - Right: `a.get i` (with Vectors)
+
+## Automation Strategy
+
+When converting many files:
+
+1. Start with 2-3 manual conversions to establish patterns
+2. Create sub-agents for batches of similar files
+3. Group files by operation type:
+   - Binary operations (add, multiply, compare)
+   - Unary operations (abs, sign, square)
+   - Reductions (sum, max, argmax)
+   - Special operations (reshape, flatten)
+
+## Final Checklist
+
+- [ ] All imports are correct
+- [ ] Return type uses `Id` monad
+- [ ] Specification uses ⦃⌜...⌝⦄ syntax
+- [ ] Postcondition binds result with ⇓
+- [ ] All array accesses use `.get`
+- [ ] Indices use `Fin n` type
+- [ ] File compiles with only `sorry` warnings
+- [ ] No unnecessary size equality proofs
+- [ ] The file could pass the lean4 compiler, you can use mcp tool to check the file.
+
+## Input Format
+
+The input will be a JSON object containing:
+```json
+{
+  "name": "numpy.function_name",
+  "description": "Brief description",
+  "url": "https://numpy.org/doc/stable/...",
+  "doc": "Full documentation string with parameters and returns",
+  "code": "Python implementation"
+}
+```
+
+## Output Format
+
+Generate a Lean 4 specification file with:
+1. Required imports
+2. Function definition with `sorry` implementation
+3. Specification theorem using Hoare triple syntax
+4. Save to: `DafnySpecs/dfy_syntax_from_doc/Numpy_FunctionName.lean`
+
+## Generation Process
+
+### Step 1: Parse the Documentation
+
+From the `doc` field, extract:
+- **Parameters**: Types and constraints
+- **Returns**: Type and properties
+- **Behavior**: What the function computes
+
+### Step 2: Determine Lean Types
+
+| NumPy Type | Lean Type | Notes |
+|------------|-----------|-------|
+| `array_like` | `Vector T n` | Use implicit `{n : Nat}` |
+| `ndarray of ints` | `Vector Int n` | |
+| `ndarray of floats` | `Vector Float n` | |
+| `int` (index) | `Fin n` | Type-safe index |
+| `axis` parameter | Omit for now | Focus on 1D |
+
+### Step 3: Identify Preconditions
+
+Common preconditions to check for:
+- Non-empty array: Use `(h : n > 0)` parameter or `Vector T (n + 1)`
+- Value constraints: e.g., `∀ i : Fin n, v.get i ≠ 0`
+- Size relationships: Handled by type system with Vectors
+
+### Step 4: Generate the Specification
+
+Template:
+```lean
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- [Description from doc] -/
+def functionName {n : Nat} (params...) : Id ReturnType :=
+  sorry
+
+/-- Specification: [describe what function does] -/
+theorem functionName_spec {n : Nat} (params...) (preconditions...) :
+    ⦃⌜precondition_formula⌝⦄
+    functionName params
+    ⦃⇓result => postcondition_formula⦄ := by
+  sorry
+```
+
+## Complete Example: numpy.argmax
+
+**Input:**
+```json
+{
+  "name": "numpy.argmax",
+  "description": "Returns the indices of the maximum values along an axis.",
+  "doc": "numpy.argmax(a, axis=None, out=None, *, keepdims=<no value>)\n\nReturns the indices of the maximum values along an axis.\n\nParameters:\n- a : array_like\n  Input array.\n- axis : int, optional\n  By default, the index is into the flattened array.\n\nReturns:\n- index_array : ndarray of ints\n  Array of indices into the array.",
+  "code": "..."
+}
+```
+
+**Output:**
+```lean
+import Std.Do.Triple
+import Std.Tactic.Do
+
+open Std.Do
+
+/-- Returns the index of the maximum value in a vector (first occurrence) -/
+def argmax {n : Nat} (arr : Vector Float n) (h : n > 0) : Id (Fin n) :=
+  sorry
+
+/-- Specification: argmax returns the index of the first maximum element -/
+theorem argmax_spec {n : Nat} (arr : Vector Float n) (h : n > 0) :
+    ⦃⌜n > 0⌝⦄
+    argmax arr h
+    ⦃⇓ret => (∀ i : Fin n, i < ret → arr.get ret > arr.get i) ∧
+             (∀ i : Fin n, ret < i → arr.get ret ≥ arr.get i)⦄ := by
+  sorry
+```
+
+Save as: `DafnySpecs/dfy_syntax_from_doc/Numpy_Argmax.lean`
+
+## Specification Patterns by Function Type
+
+### 1. Element-wise Operations (add, multiply, abs)
+```lean
+def op {n : Nat} (a b : Vector T n) : Id (Vector T n) :=
+  sorry
+
+theorem op_spec {n : Nat} (a b : Vector T n) :
+    ⦃⌜True⌝⦄
+    op a b
+    ⦃⇓r => ∀ i : Fin n, r.get i = f (a.get i) (b.get i)⦄ := by
+  sorry
+```
+
+### 2. Reduction Operations (sum, max, min)
+```lean
+def reduce {n : Nat} (arr : Vector T (n + 1)) : Id T :=
+  sorry
+
+theorem reduce_spec {n : Nat} (arr : Vector T (n + 1)) :
+    ⦃⌜True⌝⦄
+    reduce arr
+    ⦃⇓res => property_of_result⦄ := by
+  sorry
+```
+
+### 3. Index-returning Operations (argmax, argmin)
+```lean
+def argop {n : Nat} (arr : Vector T n) (h : n > 0) : Id (Fin n) :=
+  sorry
+
+theorem argop_spec {n : Nat} (arr : Vector T n) (h : n > 0) :
+    ⦃⌜n > 0⌝⦄
+    argop arr h
+    ⦃⇓idx => property_of_index⦄ := by
+  sorry
+```
+
+### 4. Array Generation (zeros, ones, arange)
+```lean
+def generate (n : Nat) (params...) : Id (Vector T n) :=
+  sorry
+
+theorem generate_spec (n : Nat) (params...) :
+    ⦃⌜constraints_on_params⌝⦄
+    generate n params
+    ⦃⇓arr => ∀ i : Fin n, arr.get i = formula⦄ := by
+  sorry
+```
+
+## Key Decisions When Generating
+
+1. **Parameter Selection**: 
+   - Ignore `axis`, `out`, `keepdims` for 1D specifications
+   - Focus on core mathematical behavior
+
+2. **Type Selection**:
+   - Use `Float` for general numeric operations
+   - Use `Int` for index operations
+   - Use `Bool` for comparison results
+
+3. **Precondition Extraction**:
+   - "non-empty" → `(h : n > 0)` or `Vector T (n + 1)`
+   - "positive values" → `∀ i : Fin n, arr.get i > 0`
+   - Division operations → non-zero divisors
+
+4. **Postcondition Formulation**:
+   - Express the mathematical property precisely
+   - Use `∀ i : Fin n` for element-wise properties
+   - Use `∃ i : Fin n` for existence properties
+
+## File Naming Convention
+
+For NumPy function `numpy.function_name`:
+- File: `Numpy_FunctionName.lean`
+- Location: `DafnySpecs/dfy_syntax_from_doc/`
+- Examples:
+  - `numpy.argmax` → `Numpy_Argmax.lean`
+  - `numpy.array_equal` → `Numpy_ArrayEqual.lean`
+  - `numpy.dot` → `Numpy_Dot.lean`
+
+## Generation Prompt Template
+
+"Given the NumPy function documentation below, generate a Lean 4 specification using Vector types and Hoare triple syntax. Extract the core mathematical behavior from the documentation, determine appropriate preconditions, and express the postcondition precisely. Save the output to `DafnySpecs/dfy_syntax_from_doc/Numpy_[FunctionName].lean`. Focus on 1D array behavior and ignore parameters like axis, out, and keepdims."
+
+## Checklist for Generated Specifications
+
+- [ ] Imports are present: `Std.Do.Triple` and `Std.Tactic.Do`
+- [ ] Function name follows Lean conventions (camelCase)
+- [ ] Appropriate use of `{n : Nat}` for vector sizes
+- [ ] Preconditions correctly extracted from documentation
+- [ ] Postcondition captures the mathematical property
+- [ ] File saved with correct naming convention
+- [ ] All functions end with `:= sorry`
+- [ ] All theorems end with `:= by sorry`

--- a/NDArray.lean
+++ b/NDArray.lean
@@ -244,9 +244,9 @@ def prod [Mul α] [OfNat α 1] {n : Nat} {shape : Vector Nat n} (arr : NDArray �
 -- TODO: cheated here
 /-- Reshape an array to a new shape with the same total size -/
 def reshape {n m : Nat} {shape1 : Vector Nat n} {shape2 : Vector Nat m}
-    (arr : NDArray α n shape1) (h : shape1.size = shape2.size) : NDArray α m shape2 :=
+    (arr : NDArray α n shape1) (h : shape1.foldl (· * ·) 1 = shape2.foldl (· * ·) 1) : NDArray α m shape2 :=
   { data := arr.data
-    size_proof := by rw [arr.size_proof, h] }
+    size_proof := by simp [arr.size_proof]; sorry }
 
 /-- Convert array to list for testing/display -/
 def toList {n : Nat} {shape : Vector Nat n} (arr : NDArray α n shape) : List α :=

--- a/NDArray/Test.lean
+++ b/NDArray/Test.lean
@@ -21,11 +21,11 @@ def testSuite : IO Unit := do
   let shape5d : Vector Nat 5 := Vector.ofFn fun i =>
     if i = 0 then 2 else if i = 1 then 3 else if i = 2 then 4 else if i = 3 then 5 else 6
   
-  IO.println s!"1D shape [5]: size = {shapeSize shape1d}"
-  IO.println s!"2D shape [3,4]: size = {shapeSize shape2d}"
-  IO.println s!"3D shape [2,3,4]: size = {shapeSize shape3d}"
-  IO.println s!"4D shape [10,28,28,3]: size = {shapeSize shape4d}"
-  IO.println s!"5D shape [2,3,4,5,6]: size = {shapeSize shape5d}"
+  IO.println s!"1D shape [5]: size = {shape1d.foldl (· * ·) 1}"
+  IO.println s!"2D shape [3,4]: size = {shape2d.foldl (· * ·) 1}"
+  IO.println s!"3D shape [2,3,4]: size = {shape3d.foldl (· * ·) 1}"
+  IO.println s!"4D shape [10,28,28,3]: size = {shape4d.foldl (· * ·) 1}"
+  IO.println s!"5D shape [2,3,4,5,6]: size = {shape5d.foldl (· * ·) 1}"
   IO.println ""
   
   -- Test 1D arrays
@@ -118,7 +118,7 @@ def testSuite : IO Unit := do
   IO.println s!"Original shape [6,4]: {arr_reshape.toList}"
   
   -- Note: Can only reshape if sizes match (6*4 = 24 = 8*3)
-  if h : shapeSize shape_before = shapeSize shape_after then
+  if h : shape_before.foldl (· * ·) 1 = shape_after.foldl (· * ·) 1 then
     let reshaped := arr_reshape.reshape h
     IO.println s!"Reshaped to [8,3]: {reshaped.toList}"
   else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,14 @@ dev = [
     "pytest>=8.2.1",
     "pytest-asyncio>=0.21.0",
     "pytest-xdist>=3.3.0",
-    
     # Code quality
     "ruff>=0.11.9",
     "mypy>=1.5.0",
-    
     # Interactive development
     "ipython>=8.0.0",
     "ipykernel>=6.29.5",
     "jupyter>=1.0.0",
+    "pytest-cov>=6.2.1",
 ]
 [tool.ruff.format]
 docstring-code-format = true

--- a/uv.lock
+++ b/uv.lock
@@ -531,6 +531,48 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/e0/98670a80884f64578f0c22cd70c5e81a6e07b08167721c7487b4d70a7ca0/coverage-7.9.1.tar.gz", hash = "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec", size = 813650, upload-time = "2025-06-13T13:02:28.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/d9/7f66eb0a8f2fce222de7bdc2046ec41cb31fe33fb55a330037833fb88afc/coverage-7.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626", size = 212336, upload-time = "2025-06-13T13:01:10.909Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/e07cb920ef3addf20f052ee3d54906e57407b6aeee3227a9c91eea38a665/coverage-7.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb", size = 212571, upload-time = "2025-06-13T13:01:12.518Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f8/96f155de7e9e248ca9c8ff1a40a521d944ba48bec65352da9be2463745bf/coverage-7.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300", size = 246377, upload-time = "2025-06-13T13:01:14.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cf/1d783bd05b7bca5c10ded5f946068909372e94615a4416afadfe3f63492d/coverage-7.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8", size = 243394, upload-time = "2025-06-13T13:01:16.23Z" },
+    { url = "https://files.pythonhosted.org/packages/02/dd/e7b20afd35b0a1abea09fb3998e1abc9f9bd953bee548f235aebd2b11401/coverage-7.9.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5", size = 245586, upload-time = "2025-06-13T13:01:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/38/b30b0006fea9d617d1cb8e43b1bc9a96af11eff42b87eb8c716cf4d37469/coverage-7.9.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd", size = 245396, upload-time = "2025-06-13T13:01:19.164Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e4/4d8ec1dc826e16791f3daf1b50943e8e7e1eb70e8efa7abb03936ff48418/coverage-7.9.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898", size = 243577, upload-time = "2025-06-13T13:01:22.433Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f4/b0e96c5c38e6e40ef465c4bc7f138863e2909c00e54a331da335faf0d81a/coverage-7.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d", size = 244809, upload-time = "2025-06-13T13:01:24.143Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/65/27e0a1fa5e2e5079bdca4521be2f5dabf516f94e29a0defed35ac2382eb2/coverage-7.9.1-cp312-cp312-win32.whl", hash = "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74", size = 214724, upload-time = "2025-06-13T13:01:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a8/d5b128633fd1a5e0401a4160d02fa15986209a9e47717174f99dc2f7166d/coverage-7.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e", size = 215535, upload-time = "2025-06-13T13:01:27.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/37/84bba9d2afabc3611f3e4325ee2c6a47cd449b580d4a606b240ce5a6f9bf/coverage-7.9.1-cp312-cp312-win_arm64.whl", hash = "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342", size = 213904, upload-time = "2025-06-13T13:01:29.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a7/a027970c991ca90f24e968999f7d509332daf6b8c3533d68633930aaebac/coverage-7.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631", size = 212358, upload-time = "2025-06-13T13:01:30.909Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/6aaed3651ae83b231556750280682528fea8ac7f1232834573472d83e459/coverage-7.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f", size = 212620, upload-time = "2025-06-13T13:01:32.256Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2a/f4b613f3b44d8b9f144847c89151992b2b6b79cbc506dee89ad0c35f209d/coverage-7.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd", size = 245788, upload-time = "2025-06-13T13:01:33.948Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d2/de4fdc03af5e4e035ef420ed26a703c6ad3d7a07aff2e959eb84e3b19ca8/coverage-7.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86", size = 243001, upload-time = "2025-06-13T13:01:35.285Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e8/eed18aa5583b0423ab7f04e34659e51101135c41cd1dcb33ac1d7013a6d6/coverage-7.9.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43", size = 244985, upload-time = "2025-06-13T13:01:36.712Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f8/ae9e5cce8885728c934eaa58ebfa8281d488ef2afa81c3dbc8ee9e6d80db/coverage-7.9.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1", size = 245152, upload-time = "2025-06-13T13:01:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c8/272c01ae792bb3af9b30fac14d71d63371db227980682836ec388e2c57c0/coverage-7.9.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751", size = 243123, upload-time = "2025-06-13T13:01:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d0/2819a1e3086143c094ab446e3bdf07138527a7b88cb235c488e78150ba7a/coverage-7.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67", size = 244506, upload-time = "2025-06-13T13:01:42.184Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4e/9f6117b89152df7b6112f65c7a4ed1f2f5ec8e60c4be8f351d91e7acc848/coverage-7.9.1-cp313-cp313-win32.whl", hash = "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643", size = 214766, upload-time = "2025-06-13T13:01:44.482Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0f/4b59f7c93b52c2c4ce7387c5a4e135e49891bb3b7408dcc98fe44033bbe0/coverage-7.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a", size = 215568, upload-time = "2025-06-13T13:01:45.772Z" },
+    { url = "https://files.pythonhosted.org/packages/09/1e/9679826336f8c67b9c39a359352882b24a8a7aee48d4c9cad08d38d7510f/coverage-7.9.1-cp313-cp313-win_arm64.whl", hash = "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d", size = 213939, upload-time = "2025-06-13T13:01:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/5b/5c6b4e7a407359a2e3b27bf9c8a7b658127975def62077d441b93a30dbe8/coverage-7.9.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0", size = 213079, upload-time = "2025-06-13T13:01:48.554Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/22/1e2e07279fd2fd97ae26c01cc2186e2258850e9ec125ae87184225662e89/coverage-7.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d", size = 213299, upload-time = "2025-06-13T13:01:49.997Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c0/4c5125a4b69d66b8c85986d3321520f628756cf524af810baab0790c7647/coverage-7.9.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f", size = 256535, upload-time = "2025-06-13T13:01:51.314Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8b/e36a04889dda9960be4263e95e777e7b46f1bb4fc32202612c130a20c4da/coverage-7.9.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029", size = 252756, upload-time = "2025-06-13T13:01:54.403Z" },
+    { url = "https://files.pythonhosted.org/packages/98/82/be04eff8083a09a4622ecd0e1f31a2c563dbea3ed848069e7b0445043a70/coverage-7.9.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece", size = 254912, upload-time = "2025-06-13T13:01:56.769Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/25/c26610a2c7f018508a5ab958e5b3202d900422cf7cdca7670b6b8ca4e8df/coverage-7.9.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683", size = 256144, upload-time = "2025-06-13T13:01:58.19Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/fb9425c4684066c79e863f1e6e7ecebb49e3a64d9f7f7860ef1688c56f4a/coverage-7.9.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f", size = 254257, upload-time = "2025-06-13T13:01:59.645Z" },
+    { url = "https://files.pythonhosted.org/packages/93/df/27b882f54157fc1131e0e215b0da3b8d608d9b8ef79a045280118a8f98fe/coverage-7.9.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10", size = 255094, upload-time = "2025-06-13T13:02:01.37Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/cad1c3dbed8b3ee9e16fa832afe365b4e3eeab1fb6edb65ebbf745eabc92/coverage-7.9.1-cp313-cp313t-win32.whl", hash = "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363", size = 215437, upload-time = "2025-06-13T13:02:02.905Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4d/fad293bf081c0e43331ca745ff63673badc20afea2104b431cdd8c278b4c/coverage-7.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7", size = 216605, upload-time = "2025-06-13T13:02:05.638Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/56/4ee027d5965fc7fc126d7ec1187529cc30cc7d740846e1ecb5e92d31b224/coverage-7.9.1-cp313-cp313t-win_arm64.whl", hash = "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c", size = 214392, upload-time = "2025-06-13T13:02:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b8/7ddd1e8ba9701dea08ce22029917140e6f66a859427406579fd8d0ca7274/coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c", size = 204000, upload-time = "2025-06-13T13:02:27.173Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "44.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2124,6 +2166,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -2165,6 +2208,7 @@ dev = [
     { name = "mypy", specifier = ">=1.5.0" },
     { name = "pytest", specifier = ">=8.2.1" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-xdist", specifier = ">=3.3.0" },
     { name = "ruff", specifier = ">=0.11.9" },
 ]
@@ -2846,6 +2890,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked PRs:
 * #96
 * __->__#95
 * #94
 * #93
 * #92


--- --- ---

### feat: port 38 NumPy operations from Dafny to Lean 4


- Port numpy operations to idiomatic Lean 4 syntax
- Create structured directory for Dafny-style specifications
- Add vector-based implementations for better type safety
- Include documentation extraction from NumPy official docs
- Clean up unnecessary files and consolidate specifications
- Establish foundation for systematic NumPy API porting